### PR TITLE
feat: New `cypress-docs` skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@ The Cypress AI Toolkit gives your AI tools the Cypress-specific context they nee
 
 Skills are instruction sets your AI tool loads to apply Cypress-specific knowledge when generating or reviewing test code. They fill the gap between what an AI learned during training and what current, well-written Cypress tests actually look like.
 
-Two skills are available now:
+Three skills are available now:
 
 - **[`cypress-author`](./skills/README.md#cypress-author)** — Improves how AI tools create, update, and fix Cypress tests. Use it when you're writing new tests or fixing broken ones.
 - **[`cypress-explain`](./skills/README.md#cypress-explain)** — Helps you understand, describe, and critique existing tests. Use it when auditing a suite, onboarding a new team member, or investigating a brittle test before rewriting it.
+- **[`cypress-docs`](./skills/README.md#cypress-docs)** - Helps your agent research and retrieve information about Cypress more efficiently and reliably.
 
 Skills work with any AI tool that accepts custom instructions, including Claude, Cursor, and GitHub Copilot.
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -22,6 +22,7 @@ Or install a specific skill with:
 ```sh
 npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-author
 npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-explain
+npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-docs
 ```
 
 See [skills.sh](https://skills.sh/) for full documentation, including how to update and remove skills. Note that the update check in the `skills` package only tracks project-level installs, not global ones.
@@ -63,6 +64,16 @@ This skill translates Cypress commands and patterns into plain language, surface
 
 > How does cy.intercept() work, and when should I use cy.wait('@alias') with it?
 
+### [`cypress-docs`](./cypress-docs)
+Helps your agent use Cypress documentation more effectively and reliably by using LLM-optimized resources and supplying guidance on how to parse and extract information while grounding answers in verifiable information.
+
+This skill is meant to help inform and support other Cypress skills.
+
+#### Example
+
+**Define a Cypress API:**
+
+> Define the Cypress `cy.prompt` API
 
 ## Troubleshooting
 

--- a/skills/cypress-author/SKILL.md
+++ b/skills/cypress-author/SKILL.md
@@ -5,7 +5,7 @@ model: inherit
 background: false
 allowed-tools: Read, Edit
 metadata:
-  version: 1.0.0
+  version: 1.0.1
 ---
 
 # Cypress Author

--- a/skills/cypress-author/references/documentation/documentation-rules.md
+++ b/skills/cypress-author/references/documentation/documentation-rules.md
@@ -1,7 +1,7 @@
 # Cypress Documentation
 
 Always prefer authoritative Cypress sources over third-party content. These include:
-  - [Cypress Docs](https://on.cypress.io/docs)
+  - [Cypress Docs](https://on.cypress.io/docs) - review that site's `/llms.txt` file for LLM-specific guidance
   - The Cypress CLI (`npx cypress --help`)
 
 Before assuming that Cypress does not support a feature, behavior, or command perform a search of authoritative sources.

--- a/skills/cypress-author/references/documentation/documentation-rules.md
+++ b/skills/cypress-author/references/documentation/documentation-rules.md
@@ -1,7 +1,7 @@
 # Cypress Documentation
 
 Always prefer authoritative Cypress sources over third-party content. These include:
-  - [Cypress Docs](https://on.cypress.io/docs) - review that site's `/llms.txt` file for LLM-specific guidance
+  - [Cypress Docs](https://docs.cypress.io) - review that site's `/llms.txt` file for LLM-specific guidance
   - The Cypress CLI (`npx cypress --help`)
 
 Before assuming that Cypress does not support a feature, behavior, or command perform a search of authoritative sources.

--- a/skills/cypress-docs/SKILL.md
+++ b/skills/cypress-docs/SKILL.md
@@ -65,37 +65,6 @@ If documentation cannot verify a claim:
 - Provide closest supported alternative (if available)
 - DO NOT invent APIs or behavior
 
-## Docs Site Map (Mental Model)
-
-    docs.cypress.io/
-    ├── /app/
-    │   ├── getting-started/
-    │   ├── core-concepts/
-    │   ├── end-to-end-testing/
-    │   ├── component-testing/
-    │   ├── api/
-    │   │   ├── commands/
-    │   │   ├── assertions/
-    │   │   └── utilities/
-    │   ├── guides/
-    │   ├── plugins/
-    │   ├── configuration/
-    │   ├── cli/
-    │   └── references/
-    │       ├── error-messages
-    │       ├── configuration
-    │       └── environment-variables
-    │
-    ├── /examples/
-    ├── /faq/
-    ├── /changelog/
-    │
-    └── /llm/   ← PRIMARY TARGET
-        ├── /markdown/api/
-        ├── /markdown/guides/
-        ├── /markdown/concepts/
-        └── /markdown/config/
-
 ## Search Strategy
 
 ### 1. Classify the Query

--- a/skills/cypress-docs/SKILL.md
+++ b/skills/cypress-docs/SKILL.md
@@ -1,0 +1,220 @@
+---
+name: cypress-docs
+description: Search and extract Cypress information from official documentation (docs.cypress.io, cypress.io); prefer LLM markdown under /llm/* and refuse unverified API or behavior claims.
+model: inherit
+background: false
+metadata:
+  version: 1.0.0
+---
+
+# Cypress Documentation
+
+## Purpose
+Enable the agent to retrieve accurate, up-to-date, and verifiable information about the Cypress testing framework by prioritizing official documentation and structured sources.
+
+## When to use
+
+Apply this skill whenever the task depends on **finding, reading, or quoting Cypress documentation** rather than general testing intuition:
+
+- **Look up facts**: commands, APIs, assertions, lifecycle hooks, configuration options, environment variables, CLI flags, plugins, or TypeScript types as documented by Cypress.
+- **Confirm behavior**: how something works in a given Cypress version, E2E vs component testing differences, browser support, or networking/cy.intercept semantics.
+- **Before asserting “Cypress can/cannot…”**: search docs first; do not rely on memory for exact signatures, defaults, or deprecated APIs.
+- **Extract structured content**: follow the LLM-optimized docs strategy below (`llms.txt`, `/llm/*`) when fetching or summarizing doc pages.
+- **Ground answers for others**: when explaining Cypress to a user, writing examples, or reviewing code where correctness must match official docs.
+
+If the user only needs **writing or fixing tests** without a documentation lookup, prefer `cypress-author`; if they only need **test explanation** without fetching docs, prefer `cypress-explain`. Use **this** skill when official documentation is the source of truth.
+
+## Source Prioritization
+
+### Primary Sources (ALWAYS search first)
+- https://docs.cypress.io
+- https://www.cypress.io
+
+## 🤖 LLM-Optimized Docs Strategy
+
+When accessing `docs.cypress.io`:
+
+1. Fetch `/llms.txt`
+
+2. Parse it to discover:
+   - LLM-friendly documentation paths
+   - Structured content endpoints
+
+3. Prefer content under `/llm/*`. Every path on the site has an optimized version hosted under `/llm` - for example, `https://docs.cypress.io/app/faq` is available at `https://docs.cypress.io/llm/markdown/app/faq.md`.
+
+4. Why:
+   - Markdown / JSON format
+   - Cleaner structure
+   - Less noise than HTML
+
+5. Fallback:
+   - If `/llm/*` is incomplete, use standard docs pages
+
+## Critical Rules
+
+### Never Assume Missing Features
+- NEVER assume Cypress does not support a feature
+- ALWAYS search before concluding
+- Retry with alternate terminology if needed
+
+### Anti-Hallucination Guard
+
+If documentation cannot verify a claim:
+
+- Say: "I could not verify this in Cypress docs"
+- Provide closest supported alternative (if available)
+- DO NOT invent APIs or behavior
+
+## Docs Site Map (Mental Model)
+
+    docs.cypress.io/
+    ├── /app/
+    │   ├── getting-started/
+    │   ├── core-concepts/
+    │   ├── end-to-end-testing/
+    │   ├── component-testing/
+    │   ├── api/
+    │   │   ├── commands/
+    │   │   ├── assertions/
+    │   │   └── utilities/
+    │   ├── guides/
+    │   ├── plugins/
+    │   ├── configuration/
+    │   ├── cli/
+    │   └── references/
+    │       ├── error-messages
+    │       ├── configuration
+    │       └── environment-variables
+    │
+    ├── /examples/
+    ├── /faq/
+    ├── /changelog/
+    │
+    └── /llm/   ← PRIMARY TARGET
+        ├── /markdown/api/
+        ├── /markdown/guides/
+        ├── /markdown/concepts/
+        └── /markdown/config/
+
+## Search Strategy
+
+### 1. Classify the Query
+
+| Query Type        | Search Location              |
+|------------------|------------------------------|
+| How do I...      | /guides/, /core-concepts/    |
+| What is...       | /core-concepts/              |
+| API / Commands   | /api/commands/               |
+| Assertions       | /api/assertions/             |
+| Config issues    | /configuration/              |
+| CI/CD            | /guides/ci-cd/               |
+| Errors           | /references/error-messages/  |
+
+### 2. Search Flow
+
+1. `/llm/*` (via `/llms.txt`)
+2. Standard docs pages
+3. `/changelog/`
+4. `cypress.io` (blog, updates)
+
+### 3. Error-Aware Routing
+
+If the query includes:
+- Error messages
+- Stack traces
+
+Then:
+1. Search `/references/error-messages`
+2. Expand to guides and API docs
+
+## Structured Extraction Rules
+
+### Commands
+- Syntax
+- Required arguments
+- Optional options
+- Return behavior
+- Example usage
+
+### Concepts
+- Definition
+- Key rules
+- Common pitfalls
+- Example
+
+### Configuration
+- Option name
+- Type
+- Default value
+- Example
+
+## Version Awareness
+
+- Detect Cypress version if provided
+- If NOT provided: assume latest stable version
+- If behavior differs by version:
+  - Explicitly call it out
+
+## Response Style Guidelines
+
+- Prefer official examples
+- Provide working code snippets
+- Keep answers concise but complete
+- Avoid speculation
+
+## Caching Strategy (Optional)
+
+Cache frequently used topics:
+- cy.visit
+- cy.get
+- cy.intercept
+- authentication patterns
+- common configuration
+
+## Confidence Annotation
+
+Internally assess confidence:
+
+- High → Direct match in official docs
+- Medium → Inferred from multiple sources
+- Low → Unclear or edge case
+
+If LOW:
+- Clearly communicate uncertainty
+
+## LLM Path Auto-Discovery
+
+- Always parse `/llms.txt`
+- Dynamically adapt to:
+  - New `/llm/*` paths
+  - Updated documentation formats
+
+## Safety Rules
+
+- NEVER invent Cypress APIs
+- NEVER guess syntax
+- ALWAYS verify behavior
+- Prefer "unknown" over incorrect
+
+## Example Behavior
+
+User: "How do I mock API requests in Cypress?"
+
+Agent should:
+1. Classify → API / network
+2. Search `/llm/markdown/api/` and `/llm/markdown/guides/`
+3. Identify `cy.intercept`
+4. Extract structured details
+5. Return:
+   - Explanation
+   - Syntax
+   - Example
+   - Notes
+
+## Summary
+
+This skill ensures:
+- Accurate answers from official sources
+- Reduced hallucination
+- Structured, high-quality outputs
+- Adaptability to evolving Cypress docs

--- a/skills/cypress-explain/SKILL.md
+++ b/skills/cypress-explain/SKILL.md
@@ -5,7 +5,7 @@ model: inherit
 background: false
 allowed-tools: Read
 metadata:
-  version: 1.0.0
+  version: 1.0.1
 ---
 
 # Cypress Explain

--- a/skills/cypress-explain/references/documentation/documentation-rules.md
+++ b/skills/cypress-explain/references/documentation/documentation-rules.md
@@ -1,5 +1,5 @@
 # Cypress Documentation
 
-Always prefer [authoritative Cypress sources](https://on.cypress.io/docs) over third-party content.
+Always prefer [authoritative Cypress sources](https://docs.cypress.io) over third-party content. Review that site's `/llms.txt` file for LLM-specific guidance
 
 Before assuming that Cypress does not support a feature, behavior, or command perform a search of authoritative sources.


### PR DESCRIPTION
## Related issue

https://github.com/cypress-io/cypress-services/issues/13161

## Summary

Create new skill to help guide agents with their use of Cypress documentation (including `https://docs.cypress.io` and `https://www.cypress.io`). Inform agents of `/llms.txt` and presence of LLM-optimized documents. Add guardrails to encourage "search before assume" and minimize API hallucination.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change: adds a new skill definition and updates existing skill docs/metadata without affecting runtime code paths.
> 
> **Overview**
> Adds a new `cypress-docs` skill that guides agents to verify Cypress behavior via official docs, prefer LLM-optimized `/llm/*` content discovered from `/llms.txt`, and refuse unverified API claims.
> 
> Updates public docs and install instructions to list the new skill, bumps `cypress-author`/`cypress-explain` metadata versions, and refreshes documentation guidance links from `on.cypress.io/docs` to `docs.cypress.io` with a note to consult `/llms.txt`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 149aeb2f754abbd0749f636ee6bc8a689264c52c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->