### PR TITLE
chore: Add readme content for releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ If you've built something that makes AI tools smarter about Cypress, this is the
 
 Read the [contributing guide](./CONTRIBUTING.md) to get started.
 
+## Releases
+### PR Checks
+Any change to a skill should have a corresponding semver update to the `version` frontmatter field in the `SKILL.md` file.
+
+Changes to any functional toolkit content (skills and mcp, not documentation for example) should update the `version` metadata under `.cursor-plugin` and `.claude-plugin` so that plugin marketplaces can see and update accordingly.
+
+### Post-PR Actions
+After an update with skill changes is merged run `gh skill publish` **from the `main` branch**. Preview changes with `--dry-run`. Version to match the plugin version above.
+
 ## License
 
 [MIT](./LICENSE)

--- a/README.md
+++ b/README.md
@@ -51,15 +51,21 @@ _Note: Listings in the Claude and Cursor official plugin marketplaces are curren
 
 If you're using another agent or prefer to pick-and-choose you can pick the portions of this repository you want.
 
-1. Install the skills using the [`skills`](https://skills.sh/) package:
+1. Install the skills using command-line tools
 
+ * [`skills`](https://skills.sh/) package:
    ```sh
    npx skills add cypress-io/ai-toolkit
    ```
+  
+  * [`GitHub CLI`](https://cli.github.com/manual/gh_skill):
+    ```sh
+    gh skill install cypress-io/ai-toolkit
+    ```
 
 2. Prompt your AI tool as you normally would. The skills will activate automatically when relevant, or invoke one directly with a slash command (e.g. `/cypress-author`).
 
-For manual installation, example prompts, and more, see the [skills documentation](./skills/README.md) or the [Cypress AI Skills docs](https://docs.cypress.io/app/tooling/ai-skills).
+    For manual installation, example prompts, and more, see the [skills documentation](./skills/README.md) or the [Cypress AI Skills docs](https://docs.cypress.io/app/tooling/ai-skills).
 
 3. The Cypress Cloud MCP configuration can be copied into your agent, or you can follow the [configuration instructions here](https://docs.cypress.io/cloud/integrations/cloud-mcp).
 
@@ -90,7 +96,7 @@ Any change to a skill should have a corresponding semver update to the `version`
 Changes to any functional toolkit content (skills and mcp, not documentation for example) should update the `version` metadata under `.cursor-plugin` and `.claude-plugin` so that plugin marketplaces can see and update accordingly.
 
 ### Post-PR Actions
-After an update with skill changes is merged run `gh skill publish` **from the `main` branch**. Preview changes with `--dry-run`. Version to match the plugin version above.
+After an update with skill changes is merged run `gh skill publish` **from the `main` branch**. Preview changes with `--dry-run`. Version to match the plugin version above - this likely will *not* match the version of individual skills, but should be thought of as a "package" version.
 
 ## License
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -8,8 +8,12 @@ For full documentation — available skills, example prompts, troubleshooting, a
 
 ## Installation
 
-### Install via skills (recommended)
-The [`skills`](https://skills.sh/) package is the fastest way to install Cypress skills.
+### Install via plugin (recommended)
+
+Coming soon; skills will be published as Cursor and Claude plugins which can be managed from within those tools. This will enable easier installation and automatic updates.
+
+### Install via skills
+The [`skills`](https://skills.sh/) package is the fastest way to install Cypress skills directly.
 
 Install all skills by running:
 
@@ -26,6 +30,26 @@ npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-docs
 ```
 
 See [skills.sh](https://skills.sh/) for full documentation, including how to update and remove skills. Note that the update check in the `skills` package only tracks project-level installs, not global ones.
+
+### Install via GitHub CLI
+
+The GitHub CLI has recently introduced tooling for agent skills.
+
+Install all skills by running:
+
+```sh
+gh skill install cypress-io/ai-toolkit
+```
+
+You can also install individual skills:
+
+```sh
+gh skill install cypress-io/ai-toolkit cypress-author
+gh skill install cypress-io/ai-toolkit cypress-explain
+gh skill install cypress-io/ai-toolkit cypress-docs
+```
+
+See [GitHub](https://cli.github.com/manual/gh_skill) for full documentation, including how to keep skills up-to-date.
 
 ### Manually
 


### PR DESCRIPTION
## Related issue

<!-- Link issue number if there is one, e.g. Closes #123 -->

## Summary

<!-- What does this change and why? -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are documentation-only and do not modify skill logic or runtime behavior.
> 
> **Overview**
> Updates docs to reflect additional installation paths for skills, adding `gh skill install` instructions alongside the existing `skills` CLI flow and clarifying that plugin-based installation is *coming soon*.
> 
> Adds a new **Releases** section to the root `README.md` documenting versioning expectations (skill `SKILL.md` semver bumps and plugin metadata updates) and the post-merge `gh skill publish` process.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc748facde87181d71c50fe5e447c08afa496c87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->