### PR TITLE
feat: Add server.json for MCP registry publishing

### DIFF
--- a/mcp/server.json
+++ b/mcp/server.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.cypress.mcp/cypress-cloud",
+  "version": "1.0.0",
+  "title": "Cypress Cloud MCP",
+  "description": "Direct access to Cypress tests results and accessibility reports in your AI workflow.",
+  "repository": {
+    "url": "https://github.com/cypress-io/ai-toolkit",
+    "source": "github"
+  },
+  "remotes": [
+    {
+      "type": "streamable-http",
+      "url": "https://mcp.cypress.io/mcp"
+    }
+  ]
+}

--- a/mcp/server.json
+++ b/mcp/server.json
@@ -3,7 +3,7 @@
   "name": "io.cypress.mcp/cypress-cloud",
   "version": "1.0.0",
   "title": "Cypress Cloud MCP",
-  "description": "Direct access to Cypress tests results and accessibility reports in your AI workflow.",
+  "description": "Direct access to Cypress test results and App Quality reports in your AI workflow.",
   "repository": {
     "url": "https://github.com/cypress-io/ai-toolkit",
     "source": "github"


### PR DESCRIPTION
## Summary

Adds `mcp/server.json` so the Cypress Cloud MCP server can be published to the official MCP registry (`registry.modelcontextprotocol.io`) under the `io.cypress.mcp/cypress-cloud` namespace.

The entry is a `remotes`-only registration pointing at the existing `https://mcp.cypress.io/mcp` streamable-HTTP endpoint — no package distribution is required.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation/registry metadata only; no application, auth, or deployment logic changes.
> 
> **Overview**
> Adds **`mcp/server.json`**, the MCP registry manifest for **Cypress Cloud MCP** (`io.cypress.mcp/cypress-cloud`).
> 
> The file registers the server with the official MCP registry using schema `2025-12-11`: metadata (title, description, repo link to `cypress-io/ai-toolkit`) and a **remotes-only** entry that points clients at the existing **`https://mcp.cypress.io/mcp`** streamable-HTTP endpoint—no new runtime code or package distribution in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4bdb32a1317af89da60a30c46c74a84b97e99e03. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->