### PR TITLE
chore: Add claude plugin instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,15 @@ The community will help shape what gets prioritized. If you're already unlocking
 
 ## Getting started
 
-The Cypress AI toolkit is published as a plugin for both Claude and Cursor. This is the easiest way to install and configure the various capabilities in this package and also enables an auto-update capability.
+### Plugin
 
-_Note: Listings in the Claude and Cursor official plugin marketplaces are currently pending. This README will be updated once they are available. Until then, this repository can be cloned and installed as a local plugin in your agent of choice._
+The Cypress AI toolkit is published as a plugin for installation into your agent. This is the easiest way to install and configure the various capabilities in this package and also enables an auto-update capability.
+
+_Note: Our listing in the Cursor official plugin marketplace is currently pending. This README will be updated once it is available. Until then, this repository can be cloned and installed as a local plugin in your agent of choice._
+
+#### Claude
+
+The plugin is published in the Claude Community Plugins marketplace - see the the [instructions here](https://github.com/anthropics/claude-plugins-community#using-this-marketplace) for configuring your Claude instance to use this marketplace. Once the marketplace is configured you can search for the `cypress` plugin.
 
 ### Manual Installation
 


### PR DESCRIPTION
## Related issue

<!-- Link issue number if there is one, e.g. Closes #123 -->

## Summary

Adding instructions for installing the toolkit as a Claude plugin now that we're listed on the marketplace

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README edits with no runtime or security impact.
> 
> **Overview**
> **Getting started** is reorganized: the plugin install path is now under a **Plugin** subsection, with wording that generalizes beyond “Claude and Cursor” to “your agent.”
> 
> The marketplace note is narrowed to **Cursor** still pending, and a new **Claude** subsection documents installing via the **Claude Community Plugins** marketplace (link to marketplace setup, then search for the `cypress` plugin).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3d309f06005cc63a01f563aca079fff8a9bc7b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->