### PR TITLE
feat: Update mcp defns to use oauth by default

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "cypress",
       "description": "Create, update, and fix Cypress tests. Connect to Cypress Cloud to see test results and use data to manage your test suite.",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "author": {
         "name": "Cypress.io",
         "email": "support@cypress.io",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cypress",
   "displayName": "Cypress",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Create, update, and fix Cypress tests. Connect to Cypress Cloud to see test results and use data to manage your test suite.",
   "author": {
     "name": "Cypress.io",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cypress",
   "displayName": "Cypress",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Create, update, and fix Cypress tests. Connect to Cypress Cloud to see test results and use data to manage your test suite.",
   "author": {
     "name": "Cypress.io",

--- a/README.md
+++ b/README.md
@@ -21,6 +21,14 @@ The Cypress AI Toolkit gives your AI tools the Cypress-specific context they nee
 
 ## What's in the toolkit
 
+### Model Context Protocol (MCP)
+
+The Cypress Cloud MCP server connects your AI coding assistants directly to Cypress Cloud, giving them access to data regarding your application's health and stability.
+
+More information about the Cypress Cloud MCP is available [here](https://docs.cypress.io/cloud/integrations/cloud-mcp).
+
+_Note:_ The MCP connection will utilize OAuth by default. If you would prefer to use a Personal Access Token (PAT) you will need to adjust the `.mcp.json` file for your agent.
+
 ### Skills
 
 Skills are instruction sets your AI tool loads to apply Cypress-specific knowledge when generating or reviewing test code. They fill the gap between what an AI learned during training and what current, well-written Cypress tests actually look like.

--- a/mcp/.mcp.claude.json
+++ b/mcp/.mcp.claude.json
@@ -2,10 +2,7 @@
   "mcpServers": {
     "cypress-cloud": {
       "type": "http",
-      "url": "https://mcp.cypress.io/mcp",
-      "headers": {
-        "Authorization": "Bearer ${CYPRESS_MCP_TOKEN}"
-      }
+      "url": "https://mcp.cypress.io/mcp"
     }
   }
 }

--- a/mcp/.mcp.cursor.json
+++ b/mcp/.mcp.cursor.json
@@ -1,10 +1,7 @@
 {
   "mcpServers": {
     "cypress-cloud": {
-      "url": "https://mcp.cypress.io/mcp",
-      "headers": {
-        "Authorization": "Bearer ${env:CYPRESS_MCP_TOKEN}"
-      }
+      "url": "https://mcp.cypress.io/mcp"
     }
   }
 }

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -1,3 +1,5 @@
 # Model Context Protocol Definitions
 
 This directory contains the MCP configuration for each agent type - unfortunately different agents use different syntax for certain things like environment variable interpolation, so it ends up being a bit duplicative.
+
+These MCP definitions default to OAuth by default - users can modify to use Personal Access Tokens (PAT) by following instructions [here](https://docs.cypress.io/cloud/integrations/cloud-mcp#Configure-AI-Assistant).

--- a/mcp/README.md
+++ b/mcp/README.md
@@ -2,4 +2,4 @@
 
 This directory contains the MCP configuration for each agent type - unfortunately different agents use different syntax for certain things like environment variable interpolation, so it ends up being a bit duplicative.
 
-These MCP definitions default to OAuth by default - users can modify to use Personal Access Tokens (PAT) by following instructions [here](https://docs.cypress.io/cloud/integrations/cloud-mcp#Configure-AI-Assistant).
+These MCP definitions default to use OAuth - you can instead use a Personal Access Token (PAT) by following instructions [here](https://docs.cypress.io/cloud/integrations/cloud-mcp#Configure-AI-Assistant).


### PR DESCRIPTION
## Related issue

<!-- Link issue number if there is one, e.g. Closes #123 -->

## Summary

1. Updating the Claude and Cursor MCP definitions to use OAuth by default.
2. Adding docs for:
    1. Explain that MCP is included in the plugin, reference MCP docs
    2. Add note explaining need to customize mcp config for oauth vs PAT

Plugin version bump should get automatically picked up by Claude community marketplace (and our Cursor submission if it ever moves). May need to manually bump `cursor.directory`, will need to see about that one

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and MCP JSON-only changes with no runtime application code or auth logic in this repo.
> 
> **Overview**
> Bumps the Cypress plugin package to **1.1.0** in the Claude and Cursor marketplace/plugin metadata so marketplaces can pick up the release.
> 
> **Cypress Cloud MCP** configs for Claude and Cursor no longer send a `Authorization: Bearer ${...}` header; they only point at `https://mcp.cypress.io/mcp`, so connections rely on **OAuth by default** instead of a PAT env var.
> 
> Documentation now calls out MCP as part of the toolkit, links to Cloud MCP docs, and notes that teams using a PAT must customize their agent `.mcp.json`. The `mcp/README` repeats that OAuth is the default and PAT setup is documented separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3aa7f9525b0b4445e4f3f3bcc39bb87c443f32b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->