### PR TITLE
Add Discord Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,12 @@
   <img src="./assets/cypress-logotype.svg#gh-dark-mode-only" alt="Cypress" width="240" />
 </p>
 
+<p align="center">
+  <a href="https://on.cypress.io/discord">
+    <img src="https://img.shields.io/badge/chat-on%20Discord-brightgreen" alt="Discord chat"/>
+  </a>
+</p>
+
 # ✨ Cypress AI Toolkit
 
 Open-source Cypress AI skills, built by the Cypress team. Works with Claude, Cursor, GitHub Copilot, and more.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <p align="center">
   <a href="https://on.cypress.io/discord">
-    <img src="https://img.shields.io/badge/chat-on%20Discord-brightgreen" alt="Discord chat"/>
+    <img src="https://img.shields.io/badge/chat-on%20Discord-brightgreen" alt="Discord chat" />
   </a>
 </p>
 


### PR DESCRIPTION
Added Discord chat link and updated project description.

## Related issue

<!-- Link issue number if there is one, e.g. Closes #123 -->

## Summary

<!-- What does this change and why? -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only README change with no code, config, or security impact.
> 
> **Overview**
> Adds a **centered Discord badge** below the Cypress logo in `README.md`, linking to `https://on.cypress.io/discord` with the standard shields.io “chat on Discord” image.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 273040baf88c296d46e899ea3a67a2ebe3fceb65. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->