### PR TITLE
Create Tap CLI skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "cypress",
       "description": "Create, update, and fix Cypress tests. Connect to Cypress Cloud to see test results and use data to manage your test suite.",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "author": {
         "name": "Cypress.io",
         "email": "support@cypress.io",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cypress",
   "displayName": "Cypress",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Create, update, and fix Cypress tests. Connect to Cypress Cloud to see test results and use data to manage your test suite.",
   "author": {
     "name": "Cypress.io",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cypress",
   "displayName": "Cypress",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Create, update, and fix Cypress tests. Connect to Cypress Cloud to see test results and use data to manage your test suite.",
   "author": {
     "name": "Cypress.io",

--- a/README.md
+++ b/README.md
@@ -39,11 +39,12 @@ _Note:_ The MCP connection will utilize OAuth by default. If you would prefer to
 
 Skills are instruction sets your AI tool loads to apply Cypress-specific knowledge when generating or reviewing test code. They fill the gap between what an AI learned during training and what current, well-written Cypress tests actually look like.
 
-Three skills are available now:
+Four skills are available now:
 
 - **[`cypress-author`](./skills/README.md#cypress-author)** — Improves how AI tools create, update, and fix Cypress tests. Use it when you're writing new tests or fixing broken ones.
 - **[`cypress-explain`](./skills/README.md#cypress-explain)** — Helps you understand, describe, and critique existing tests. Use it when auditing a suite, onboarding a new team member, or investigating a brittle test before rewriting it.
 - **[`cypress-docs`](./skills/README.md#cypress-docs)** - Helps your agent research and retrieve information about Cypress more efficiently and reliably.
+- **[`cypress-tap`](./skills/README.md#cypress-tap)** — Drives a running Cypress open-mode session to run specs, inspect results, diagnose failures, and query the app under test without GUI interaction.
 
 Skills work with any AI tool that accepts custom instructions, including Claude, Cursor, and GitHub Copilot.
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -27,6 +27,7 @@ Or install a specific skill with:
 npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-author
 npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-explain
 npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-docs
+npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-tap
 ```
 
 See [skills.sh](https://skills.sh/) for full documentation, including how to update and remove skills. Note that the update check in the `skills` package only tracks project-level installs, not global ones.
@@ -47,6 +48,7 @@ You can also install individual skills:
 gh skill install cypress-io/ai-toolkit cypress-author
 gh skill install cypress-io/ai-toolkit cypress-explain
 gh skill install cypress-io/ai-toolkit cypress-docs
+gh skill install cypress-io/ai-toolkit cypress-tap
 ```
 
 See [GitHub](https://cli.github.com/manual/gh_skill) for full documentation, including how to keep skills up-to-date.
@@ -98,6 +100,17 @@ This skill is meant to help inform and support other Cypress skills.
 **Define a Cypress API:**
 
 > Define the Cypress `cy.prompt` API
+
+### [`cypress-tap`](./cypress-tap)
+Drives a running Cypress open-mode session through `cypress tap` so your agent can run and rerun specs, inspect reporter and command logs, diagnose failures, and query or rewind the app under test without GUI interaction.
+
+Use it when authoring or debugging Cypress tests against an existing `cypress open` session. It requires Cypress 15.21 or later and a Chromium-family browser.
+
+#### Example
+
+**Diagnose a failing spec:**
+
+> Run the checkout spec in my open Cypress session, diagnose the failure, and inspect the app at the failing command.
 
 ## Troubleshooting
 

--- a/skills/cypress-tap/SKILL.md
+++ b/skills/cypress-tap/SKILL.md
@@ -1,0 +1,188 @@
+---
+name: cypress-tap
+description: >-
+  Drives a running Cypress open-mode session through `cypress tap` to run and
+  rerun specs, wait for fresh results, inspect reporter and command logs, and
+  query or rewind the app under test through DOM, accessibility, styles, and
+  snapshots. Use when authoring or debugging Cypress e2e or component specs,
+  discovering selectors, diagnosing failures, or verifying test behavior
+  without GUI interaction. Not for one-shot headless runs. Requires Cypress
+  15.21+, a Chromium-family browser, and a running `cypress open` session.
+---
+
+# Driving Cypress with `cypress tap`
+
+`cypress tap` controls an already-running `cypress open` session. Use it to iterate on specs,
+inspect the reporter and command log, and read the app under test without GUI interaction.
+Use `cypress run` instead for a one-shot headless batch.
+
+## Prerequisites
+
+- A Cypress build containing `tap` (versioned 15.21.0+) must be compatible with the session.
+  The version floor does not guarantee that a stable package has been published; verify the
+  actual binary with `npx cypress tap --help`.
+- The session must use Electron, Chrome, Chromium, or Edge. Firefox and WebKit are unsupported.
+- `cypress open` and any configured `baseUrl` dev server must already be running.
+- The cwd chooses both the Cypress binary and the automatically selected session. When the
+  target project pins an older Cypress, run `tap` from a compatible checkout and pass
+  `--session <pid>` on every call.
+
+## Choose the workflow
+
+- **No session:** start `cypress open`, then poll `status` until it includes a `pid`.
+- **Run or rerun:** `specs` → capture `startedAt` → `run` → wait for a fresh verdict.
+- **Author a spec:** run a probe spec → `aria` → targeted `dom` → `inspect`.
+- **Diagnose a failure:** `reporter` → `reporter --test-id` → `command` → `pin` → app reads.
+- **One noninteractive batch:** use `cypress run`, not `tap`.
+
+## Required reading by task
+
+- Before starting, selecting, running, or polling a session, read
+  [references/session-lifecycle.md](references/session-lifecycle.md).
+- Before using `specs`, `run`, `reporter`, or `command`, read
+  [references/reading-results.md](references/reading-results.md).
+- Before using `dom`, `aria`, `inspect`, or `pin`, read
+  [references/reading-the-app.md](references/reading-the-app.md).
+- When a command fails, hangs, targets the wrong project, or returns surprising output, read
+  [references/troubleshooting.md](references/troubleshooting.md).
+- For spec authoring, flake hunting, run reporting, and failure diagnosis, read
+  [references/recipes.md](references/recipes.md).
+
+Read only the references required for the current task.
+
+## Core commands
+
+- `sessions`: reachable sessions, project roots, testing types, browsers, and renderer health.
+- `status`: lifecycle stage, selected spec, run identity, counts, build error, and active pin.
+- `specs`: runnable project-relative spec paths for the session's testing type.
+- `run <spec>`: dispatches a spec and returns immediately.
+- `reporter`: spec overview and test ids; with `--test-id`, the complete test attempt.
+- `command`: one command-log row with network data, snapshots, and console properties.
+- `pin`: rewinds the app frame to a command snapshot.
+- `dom`, `aria`, `inspect`: read the settled app or currently pinned snapshot.
+
+All commands accept `--session <pid>`, `--json`, and `--timeout <ms>`. Use
+`npx cypress tap <command> --help` for command-specific flags; help needs no running session.
+
+## The non-negotiable verdict rule
+
+`run` confirms dispatch, not execution, and returns before the new run starts. During that gap,
+`status` and app reads can still return the previous run's plausible verdict and page.
+
+For every explicit run:
+
+1. Read the current `startedAt`.
+2. Dispatch exactly one spec.
+3. Poll one `status --json` response at a time.
+4. Accept only `passed` or `failed` with a non-empty, changed `startedAt` **and** the expected
+   `spec`.
+5. Bound the loop and fail if no matching fresh verdict arrives.
+
+Saving the active spec triggers an automatic watcher run. After editing, either use that run or
+let it settle before taking a baseline and dispatching another. Never intentionally put two runs
+in flight.
+
+Blank and partial status payloads occur transiently. Treat missing fields as "keep waiting," not
+as a state change. Require every field used in a comparison to be present.
+
+Lifecycle order:
+
+`not connected` → `browser not selected` → `spec not selected` → `loading` → `running` →
+`passed` | `failed`
+
+Only `passed` and `failed` are verdicts. A build failure is `failed` with the diagnostic in
+`status.error`, possibly before any tests exist.
+
+## Minimal run loop
+
+Read all synchronization fields from one status response. Each invocation starts Node, so sleep
+at least two seconds and do not make separate status calls per field.
+
+```bash
+tap_state () {
+  npx cypress tap status --json 2>/dev/null | node -e "
+    try {
+      const v = JSON.parse(require('fs').readFileSync(0, 'utf8'))
+      process.stdout.write([v.status ?? '', v.startedAt ?? '', v.pid ?? '', v.spec ?? ''].join('|'))
+    } catch {}
+  "
+}
+
+SPEC=cypress/e2e/login.cy.ts
+IFS='|' read -r _ before _ _ < <(tap_state)
+npx cypress tap run "$SPEC" || exit 1
+
+fresh=0
+for _ in $(seq 1 120); do
+  IFS='|' read -r stage started_at _ ran_spec < <(tap_state)
+  case "$stage" in
+    passed|failed)
+      if [ -n "$started_at" ] && [ "$started_at" != "$before" ] \
+        && [ "$ran_spec" = "$SPEC" ]; then
+        fresh=1
+        break
+      fi
+      ;;
+  esac
+  sleep 2
+done
+[ "$fresh" -eq 1 ] || { echo "no fresh verdict" >&2; exit 1; }
+
+npx cypress tap status
+npx cypress tap reporter
+```
+
+Copy `SPEC` from `tap specs`; do not guess paths. This snippet uses process substitution
+(`< <(...)`) and therefore requires bash or zsh, not POSIX `sh`.
+
+## Critical correctness rules
+
+1. **Target the intended session.** If several sessions exist, or auto-selection behaves oddly,
+   inspect `sessions` and pass `--session <pid>`. Auto-selection can choose another project or an
+   unresponsive session.
+2. **Preserve the binary location.** Cwd controls `npx` resolution on every call. If using a
+   separate tap-capable checkout, bind it once:
+
+   ```bash
+   tap_cli () {
+     npx --prefix "/path/to/tap-capable-checkout" cypress tap -s 73952 "$@"
+   }
+   ```
+
+3. **Do not parse failed commands.** Results use stdout and failures use stderr, but a failure
+   generally leaves stdout empty. Check the exit code before parsing JSON. An ambiguous selector
+   is the intentional exception: it exits `1` and prints matches on stdout.
+4. **Do not discard dispatch stdout while checking compatibility.** An older Cypress prints
+   `Unknown command "tap"` and usage text to stdout; redirecting it hides the cause.
+5. **Redirect potentially large JSON.** `reporter --test-id --json` and `command --json` can be
+   hundreds of kilobytes. Save them to a file and parse the file.
+6. **Check truncation before concluding absence.** `dom` and `aria` cap output. Narrow the
+   selector or raise the limit when `(output truncated)` appears.
+7. **Sanity-check the live frame before concluding absence.** A trailing pending/skipped test
+   can leave the settled runner on a blank placeholder while app reads still exit `0`. Confirm a
+   known app anchor. If the frame is blank, pin a snapshot from the last real command and read
+   that state instead.
+8. **Read results before editing or deleting the spec.** Results and snapshots live in the
+   Cypress app's memory and can disappear on rerun, restart, rename, or deletion.
+9. **Clear pins.** After inspecting a command snapshot, run `pin --clear`; otherwise later app
+   reads continue to describe the pinned past.
+
+## Output contract
+
+- Human output is for reading; `--json` is for parsing and may contain much more data.
+- Exit `0` means success and exit `1` means failure, except `status` exits `0` for every known
+  lifecycle stage, including `not connected`.
+- `dom`, `aria`, and `inspect` require exactly one selected element. Ambiguity exits `1` with
+  candidate selectors. A miss is not a CLI failure: `dom` and `inspect` report `found:false`;
+  `aria` returns an empty tree both for a miss and for an element with no accessibility node.
+- Failures are prose without stable error codes. Branch on exit status, not message text.
+
+## Performance defaults
+
+- Use one `status --json` call per poll and sleep at least two seconds.
+- Bound every loop by attempts; a degraded session can make each call much slower than expected.
+- Prefer one wide `reporter --test-id` read over one `command` call per row.
+- After a fresh verdict and live-frame sanity check, independent `aria`, `dom`, and `inspect`
+  reads may run concurrently.
+- If calls are unexpectedly slow, inspect `sessions` for `rendererResponsive: false`; increasing
+  `--timeout` does not recover a wedged renderer.

--- a/skills/cypress-tap/SKILL.md
+++ b/skills/cypress-tap/SKILL.md
@@ -8,6 +8,8 @@ description: >-
   discovering selectors, diagnosing failures, or verifying test behavior
   without GUI interaction. Not for one-shot headless runs. Requires Cypress
   15.21+, a Chromium-family browser, and a running `cypress open` session.
+metadata:
+  version: 1.0.0
 ---
 
 # Driving Cypress with `cypress tap`

--- a/skills/cypress-tap/SKILL.md
+++ b/skills/cypress-tap/SKILL.md
@@ -18,41 +18,36 @@ Use `cypress run` instead for a one-shot headless batch.
 
 ## Prerequisites
 
-- A Cypress build containing `tap` (versioned 15.21.0+) must be compatible with the session.
-  The version floor does not guarantee that a stable package has been published; verify the
-  actual binary with `npx cypress tap --help`.
+- Confirm from package metadata or the lockfile that the resolved Cypress is 15.21.0+ and
+  contains `tap`. Do not use `tap --help` to probe an unknown older build; prereleases below the
+  version floor may attempt session discovery instead of printing help.
 - The session must use Electron, Chrome, Chromium, or Edge. Firefox and WebKit are unsupported.
 - `cypress open` and any configured `baseUrl` dev server must already be running.
 - The cwd chooses both the Cypress binary and the automatically selected session. When the
   target project pins an older Cypress, run `tap` from a compatible checkout and pass
   `--session <pid>` on every call.
 
-## Choose the workflow
+## Route by task
 
-- **No session:** start `cypress open`, then poll `status` until it includes a `pid`.
-- **Run or rerun:** `specs` → capture `startedAt` → `run` → wait for a fresh verdict.
-- **Author a spec:** run a probe spec → `aria` → targeted `dom` → `inspect`.
-- **Diagnose a failure:** `reporter` → `reporter --test-id` → `command` → `pin` → app reads.
+- **Start, select, or poll a session:** read
+  [session-lifecycle.md](references/session-lifecycle.md).
+- **Run a spec or read its results:** read [session-lifecycle.md](references/session-lifecycle.md)
+  and [reading-results.md](references/reading-results.md).
+- **Author or inspect a spec:** read [recipes.md](references/recipes.md) and
+  [reading-the-app.md](references/reading-the-app.md).
+- **Diagnose a failure:** read [recipes.md](references/recipes.md),
+  [reading-results.md](references/reading-results.md), and
+  [reading-the-app.md](references/reading-the-app.md).
+- **Command failure, hang, wrong project, or surprising output:** read
+  [troubleshooting.md](references/troubleshooting.md).
 - **One noninteractive batch:** use `cypress run`, not `tap`.
-
-## Required reading by task
-
-- Before starting, selecting, running, or polling a session, read
-  [references/session-lifecycle.md](references/session-lifecycle.md).
-- Before using `specs`, `run`, `reporter`, or `command`, read
-  [references/reading-results.md](references/reading-results.md).
-- Before using `dom`, `aria`, `inspect`, or `pin`, read
-  [references/reading-the-app.md](references/reading-the-app.md).
-- When a command fails, hangs, targets the wrong project, or returns surprising output, read
-  [references/troubleshooting.md](references/troubleshooting.md).
-- For spec authoring, flake hunting, run reporting, and failure diagnosis, read
-  [references/recipes.md](references/recipes.md).
 
 Read only the references required for the current task.
 
 ## Core commands
 
-- `sessions`: reachable sessions, project roots, testing types, browsers, and renderer health.
+- `sessions`: reachable sessions, project roots, testing types, and browsers; JSON adds support
+  and renderer health.
 - `status`: lifecycle stage, selected spec, run identity, counts, build error, and active pin.
 - `specs`: runnable project-relative spec paths for the session's testing type.
 - `run <spec>`: dispatches a spec and returns immediately.
@@ -61,8 +56,8 @@ Read only the references required for the current task.
 - `pin`: rewinds the app frame to a command snapshot.
 - `dom`, `aria`, `inspect`: read the settled app or currently pinned snapshot.
 
-All commands accept `--session <pid>`, `--json`, and `--timeout <ms>`. Use
-`npx cypress tap <command> --help` for command-specific flags; help needs no running session.
+All commands accept `--session <pid>`, `--json`, and `--timeout <ms>`. On a confirmed supported
+build, use `npx cypress tap <command> --help` for command-specific flags.
 
 ## The non-negotiable verdict rule
 
@@ -74,92 +69,38 @@ For every explicit run:
 1. Read the current `startedAt`.
 2. Dispatch exactly one spec.
 3. Poll one `status --json` response at a time.
-4. Accept only `passed` or `failed` with a non-empty, changed `startedAt` **and** the expected
-   `spec`.
+4. Accept only `passed` or `failed` for the expected `spec` with a non-empty, changed
+   `startedAt`. `startedAt` is null only when no run has ever started for that spec in the
+   session — a build failure on first selection. A build that fails on rerun or on a watcher
+   rebuild still advances `startedAt`, so it takes the normal path. Keep the null fallback
+   (a changed observable baseline, or a preceding `loading`/`running` observation) for the
+   first-selection case only.
 5. Bound the loop and fail if no matching fresh verdict arrives.
 
 Saving the active spec triggers an automatic watcher run. After editing, either use that run or
 let it settle before taking a baseline and dispatching another. Never intentionally put two runs
 in flight.
 
-Blank and partial status payloads occur transiently. Treat missing fields as "keep waiting," not
-as a state change. Require every field used in a comparison to be present.
-
-Lifecycle order:
-
-`not connected` → `browser not selected` → `spec not selected` → `loading` → `running` →
-`passed` | `failed`
+Blank and partial payloads from a successful `status` call occur transiently. Treat missing
+fields as "keep waiting," not as a state change. A nonzero `status` exit is a command failure,
+not a partial read: stop polling and report it.
 
 Only `passed` and `failed` are verdicts. A build failure is `failed` with the diagnostic in
-`status.error`, possibly before any tests exist.
-
-## Minimal run loop
-
-Read all synchronization fields from one status response. Each invocation starts Node, so sleep
-at least two seconds and do not make separate status calls per field.
-
-```bash
-tap_state () {
-  local json
-  json=$(npx cypress tap status --json 2>/dev/null) || return 1
-  printf '%s' "$json" | node -e "
-    try {
-      const v = JSON.parse(require('fs').readFileSync(0, 'utf8'))
-      if (!v || typeof v.status !== 'string' || !v.status) process.exit(1)
-      if (['passed', 'failed'].includes(v.status) && (!v.startedAt || !v.spec)) process.exit(1)
-      console.log([v.status, v.startedAt ?? '', v.pid ?? '', v.spec ?? ''].join('|'))
-    } catch { process.exit(1) }
-  "
-}
-
-SPEC=cypress/e2e/login.cy.ts
-while ! IFS='|' read -r _ before _ _ < <(tap_state); do sleep 2; done
-npx cypress tap run "$SPEC" || exit 1
-
-fresh=0
-for _ in $(seq 1 120); do
-  if IFS='|' read -r stage started_at _ ran_spec < <(tap_state); then
-    case "$stage" in
-      passed|failed)
-        if [ -n "$started_at" ] && [ "$started_at" != "$before" ] \
-          && [ "$ran_spec" = "$SPEC" ]; then
-          fresh=1
-          break
-        fi
-        ;;
-    esac
-  fi
-  sleep 2
-done
-[ "$fresh" -eq 1 ] || { echo "no fresh verdict" >&2; exit 1; }
-
-npx cypress tap status
-npx cypress tap reporter
-```
-
-Copy `SPEC` from `tap specs`; do not guess paths. This snippet uses process substitution
-(`< <(...)`) and therefore requires bash or zsh, not POSIX `sh`. Baseline capture retries until
-it gets a structurally complete status; otherwise a transient blank read could make the previous
-run's verdict appear fresh after dispatch.
+`status.error`, possibly before any tests exist. `status` is the only surface that carries that
+diagnostic — `reporter` renders a failed build as an empty spec.
 
 ## Critical correctness rules
 
 1. **Target the intended session.** If several sessions exist, or auto-selection behaves oddly,
    inspect `sessions` and pass `--session <pid>`. Auto-selection can choose another project or an
    unresponsive session.
-2. **Preserve the binary location.** Cwd controls `npx` resolution on every call. If using a
-   separate tap-capable checkout, bind it once:
-
-   ```bash
-   tap_cli () {
-     npx --prefix "/path/to/tap-capable-checkout" cypress tap -s 73952 "$@"
-   }
-   ```
-
-3. **Do not parse failed commands.** Results use stdout and failures use stderr, but a failure
-   generally leaves stdout empty. Check the exit code before parsing JSON. An ambiguous selector
-   is the intentional exception: it exits `1` and prints matches on stdout.
-4. **Do not discard dispatch stdout while checking compatibility.** An older Cypress prints
+2. **Preserve the binary location.** Cwd controls `npx` resolution on every call. When the
+   project pins an older Cypress, run commands from a compatible checkout and pass
+   `--session <pid>`.
+3. **Do not parse failed commands.** Check the exit code before parsing JSON. Supported-build
+   failures generally use stderr, but older compatibility failures may use stdout. An ambiguous
+   selector is the intentional exception: it exits `1` and lists matches on stdout.
+4. **Do not discard dispatch stdout while checking compatibility.** An older Cypress may print
    `Unknown command "tap"` and usage text to stdout; redirecting it hides the cause.
 5. **Redirect potentially large JSON.** `reporter --test-id --json` and `command --json` can be
    hundreds of kilobytes. Save them to a file and parse the file.
@@ -172,13 +113,19 @@ run's verdict appear fresh after dispatch.
 8. **Read results before editing or deleting the spec.** Results and snapshots live in the
    Cypress app's memory and can disappear on rerun, restart, rename, or deletion.
 9. **Clear pins.** After inspecting a command snapshot, run `pin --clear`; otherwise later app
-   reads continue to describe the pinned past.
+   reads continue to describe the pinned past. An exit-`0` `cleared:false` result is a benign
+   no-op even if human output says `FAILED TO CLEAR PIN`.
+10. **Use the right reader for live state.** Use `aria` for current form-control values:
+    `dom` and `inspect` can show the initial HTML `value` attribute, and `inspect` may omit the
+    accessibility value. Use `dom` for exact live-region, toast, status, and label text because
+    `aria` may omit descendant text.
 
 ## Output contract
 
 - Human output is for reading; `--json` is for parsing and may contain much more data.
-- Exit `0` means success and exit `1` means failure, except `status` exits `0` for every known
-  lifecycle stage, including `not connected`.
+- `status` exits `0` for known lifecycle stages, including `not connected`. Discovery,
+  compatibility, unsupported-browser, and renderer failures exit `1`, sometimes with no stdout;
+  a poller must fail fast on that nonzero exit.
 - `dom`, `aria`, and `inspect` require exactly one selected element. Ambiguity exits `1` with
   candidate selectors. A miss is not a CLI failure: `dom` and `inspect` report `found:false`;
   `aria` returns an empty tree both for a miss and for an element with no accessibility node.
@@ -186,10 +133,7 @@ run's verdict appear fresh after dispatch.
 
 ## Performance defaults
 
-- Use one `status --json` call per poll and sleep at least two seconds.
-- Bound every loop by attempts; a degraded session can make each call much slower than expected.
-- Prefer one wide `reporter --test-id` read over one `command` call per row.
-- After a fresh verdict and live-frame sanity check, independent `aria`, `dom`, and `inspect`
-  reads may run concurrently.
-- If calls are unexpectedly slow, inspect `sessions` for `rendererResponsive: false`; increasing
-  `--timeout` does not recover a wedged renderer.
+- Prefer one `reporter --test-id` read over one `command` call per row.
+- After a fresh verdict and live-frame sanity check, independent app reads may run concurrently.
+- If bounded status polling fails, inspect `sessions` for `rendererResponsive: false`; restart a
+  wedged renderer instead of increasing `--timeout`.

--- a/skills/cypress-tap/SKILL.md
+++ b/skills/cypress-tap/SKILL.md
@@ -100,30 +100,35 @@ at least two seconds and do not make separate status calls per field.
 
 ```bash
 tap_state () {
-  npx cypress tap status --json 2>/dev/null | node -e "
+  local json
+  json=$(npx cypress tap status --json 2>/dev/null) || return 1
+  printf '%s' "$json" | node -e "
     try {
       const v = JSON.parse(require('fs').readFileSync(0, 'utf8'))
-      process.stdout.write([v.status ?? '', v.startedAt ?? '', v.pid ?? '', v.spec ?? ''].join('|'))
-    } catch {}
+      if (!v || typeof v.status !== 'string' || !v.status) process.exit(1)
+      if (['passed', 'failed'].includes(v.status) && (!v.startedAt || !v.spec)) process.exit(1)
+      console.log([v.status, v.startedAt ?? '', v.pid ?? '', v.spec ?? ''].join('|'))
+    } catch { process.exit(1) }
   "
 }
 
 SPEC=cypress/e2e/login.cy.ts
-IFS='|' read -r _ before _ _ < <(tap_state)
+while ! IFS='|' read -r _ before _ _ < <(tap_state); do sleep 2; done
 npx cypress tap run "$SPEC" || exit 1
 
 fresh=0
 for _ in $(seq 1 120); do
-  IFS='|' read -r stage started_at _ ran_spec < <(tap_state)
-  case "$stage" in
-    passed|failed)
-      if [ -n "$started_at" ] && [ "$started_at" != "$before" ] \
-        && [ "$ran_spec" = "$SPEC" ]; then
-        fresh=1
-        break
-      fi
-      ;;
-  esac
+  if IFS='|' read -r stage started_at _ ran_spec < <(tap_state); then
+    case "$stage" in
+      passed|failed)
+        if [ -n "$started_at" ] && [ "$started_at" != "$before" ] \
+          && [ "$ran_spec" = "$SPEC" ]; then
+          fresh=1
+          break
+        fi
+        ;;
+    esac
+  fi
   sleep 2
 done
 [ "$fresh" -eq 1 ] || { echo "no fresh verdict" >&2; exit 1; }
@@ -133,7 +138,9 @@ npx cypress tap reporter
 ```
 
 Copy `SPEC` from `tap specs`; do not guess paths. This snippet uses process substitution
-(`< <(...)`) and therefore requires bash or zsh, not POSIX `sh`.
+(`< <(...)`) and therefore requires bash or zsh, not POSIX `sh`. Baseline capture retries until
+it gets a structurally complete status; otherwise a transient blank read could make the previous
+run's verdict appear fresh after dispatch.
 
 ## Critical correctness rules
 

--- a/skills/cypress-tap/references/reading-results.md
+++ b/skills/cypress-tap/references/reading-results.md
@@ -1,287 +1,94 @@
-# Reading results: `reporter` and `command`
+# Reading results: `specs`, `run`, `reporter`, and `command`
 
-These two reproduce the Cypress app's reporter panel in the terminal. Both are readable once
-the lifecycle reaches `running` — you do not have to wait for a verdict (unlike the app reads
-in `reading-the-app.md`). During `loading`, before Mocha starts, they report
-`SPEC_NOT_STARTED`; before any spec has ever run they report "No spec has run yet."
-
-## `specs` — what is runnable
+## Choose and run a spec
 
 ```bash
 npx cypress tap specs
-```
-
-```
-SPECS (3)
-  cypress/e2e/login.cy.ts     2 hours ago
-  cypress/e2e/cart.cy.ts      yesterday
-  cypress/e2e/search.cy.ts    3 days ago
-```
-
-Most recently modified first, which usually puts the spec you are working on at the top.
-Paths are POSIX and project-relative — exactly the form `run` wants. Only the **open
-testing type** is listed; a spec that exists but is missing here is outside the project's
-`specPattern`.
-
-`--json` adds `lastModifiedTimestamp` for sorting; the human view shows git's relative
-phrasing only.
-
-## `run` — start or rerun
-
-```bash
 npx cypress tap run cypress/e2e/login.cy.ts
 ```
 
-```
-▶ cypress/e2e/login.cy.ts
+`specs` lists project-relative paths for the session's current testing type, most recently
+modified first. Copy a listed path exactly; files outside `specPattern` do not appear. Under
+`--json`, each entry carries the path as `relativePath`.
 
-  testing type  e2e
-  browser       Chrome
-```
+`run` confirms dispatch only. Use the fresh-verdict workflow in `SKILL.md` before trusting
+status or reading the app. A build failure reaches `failed` with its diagnostic in
+`status.error`, possibly before tests exist.
 
-That output confirms what was *launched*, not what happened. Poll `status` for the outcome
-(see `session-lifecycle.md`). Rerunning the same path is how you re-execute after editing
-either the spec or the app.
-
-A build failure reaches a `failed` verdict before tests exist. In that case `reporter` is an
-empty run and the useful diagnostic is `status.error`, which carries the bundler or compile
-failure.
-
-## `reporter` — the spec overview
-
-With no `--test-id`, you get the header stats plus every suite and test, each with the **test
-id** the other commands take:
+## Read the spec overview
 
 ```bash
 npx cypress tap reporter
 ```
 
-```
-cypress/e2e/login.cy.ts  (started at 10:42:19 AM)
-✓ 4  ✖ 1  ○ --  01:07
+The overview contains run counts, suites, tests, retries, and test ids such as `r4`. Use those
+ids with `reporter --test-id`, `command`, and `pin`. Test ids depend on the suite structure, so
+never infer one from declaration order or from examples; copy it from `reporter`.
 
-Login > form
-   r3  ✓ shows validation errors    412ms
-   r4  ✖ submits valid credentials  2.1s
-   r5  ○ remembers the user         (2 attempts)
-```
+`reporter` and `command` are readable once the runner exists, including while tests are
+running. During `loading` and before the first run, both report `No spec has run yet.`
 
-Test ids are the runner's own (`r3`, `r4`, …). Suite sections are the full suite path joined
-with ` > `, so titles can be pasted straight into a case-sensitive search. A retried test
-shows its attempt count and lists each attempt underneath — captured from a live run of a
-test configured with `{ retries: 2 }`:
+`reporter` cannot report a build failure. Its spec-level result carries no error field, so a spec
+that failed to compile renders as `No tests were found in this spec.` — indistinguishable from a
+spec that genuinely declares no tests. If no runner ever started, `reporter` instead fails with
+`SPEC_NOT_STARTED`. Never diagnose an empty-looking `reporter` on its own: read `status.error`
+first.
 
-```
-tap skill check
-   r3  ✖ retries then fails  24ms  (3 attempts)
-         ✖ attempt 1  46ms
-         ✖ attempt 2  16ms
-         ✖ attempt 3  24ms
-```
-
-`--attempt` then selects one (1-based, attempt 1 = the first run); out of range, the failure
-names how many exist: *"Looked for `--attempt` 4. Test "r3" has 3 attempts."*
-
-## `reporter --test-id` — one test in full
+## Read one test attempt
 
 ```bash
 npx cypress tap reporter --test-id r4
-npx cypress tap reporter --test-id r4 --attempt 1   # an earlier retry
+npx cypress tap reporter --test-id r4 --attempt 1
 ```
 
-This is the whole panel for one attempt: the `cy.session`s it used, its spies/stubs, its
-`cy.intercept` routes, the complete command log split into hook sections, and the error with
-its code frame when it failed.
+The test view includes routes, hooks, command-log rows, retries, and failure output. `--attempt`
+is 1-based and defaults to the latest attempt.
 
-A failing hook may attach its error to the affected test while leaving the command log empty
-because no Cypress command ran. Read the test's error panel before assuming an empty log means
-the failure details were lost.
+Read the full test view before deciding which row failed. Hook errors and uncaught-exception
+events may be the cause even when the test body's final command looks suspicious.
 
-```
-✖ Login > form > submits valid credentials  failed
+When validating a newly authored test, also confirm:
 
-ROUTES (1)
-  METHOD  MATCHER          STUBBED  ALIAS  #
-  POST    **/api/session   yes      login  1
+- command subjects and assertion messages match the intended elements;
+- stubbed routes have nonzero match counts;
+- the commands describe the user flow the test was meant to exercise.
 
-BEFORE EACH · h1
-   1  visit   /login
+## Command ids
 
-TEST BODY · r4
-   1  get     [data-cy=email]
-   2  -type   user@example.com
-   3  get     [data-cy=submit]
-   4  -click
-   5  wait    @login  @login
-   6  assert  expected '/login' to equal '/dashboard'  ✖
+Each reporter row has an id accepted by `command` and `pin`:
 
-✖ AssertionError
-  Timed out retrying after 4000ms: expected '/login' to equal '/dashboard'
+- A number such as `5` chooses the test-body row first, then a unique hook match.
+- A hook-qualified id such as `h1:3` selects row 3 in hook `h1`.
+- `r4:2` explicitly selects row 2 in test body `r4`.
+- Event and system rows use attempt-wide ids such as `e1`.
+- Route registrations are listed in `ROUTES`; they are not command rows.
 
-  cypress/e2e/login.cy.ts:24:31
-    22 |     cy.get('[data-cy=submit]').click()
-    23 |     cy.wait('@login')
-  > 24 |     cy.location('pathname').should('eq', '/dashboard')
-       |                                   ^
-```
+Numbering restarts in each hook. If an unqualified number matches multiple hook rows and no
+test-body row, the command lists candidates; rerun with a qualified id.
 
-`--attempt` is 1-based and requires `--test-id`; omit it for the latest attempt.
-
-### Command ids
-
-The number in the left column is the **command id** that `command` and `pin` take. Read them
-carefully — the numbering is per hook section, so it restarts:
-
-- A plain number (`5`) resolves to the **test body** first, then to a unique match elsewhere.
-- Qualify it as `<hookId>:<number>` (`h1:3`) to target a hook row directly. The hook id is
-  printed in the section heading — `BEFORE EACH · h1`, and for the test's own commands the
-  section is headed by the test id itself (`TEST BODY · r4`), so `-c r4:2` also works.
-- Event and system rows — `xhr`, `fetch`, uncaught exceptions, driver annotations — are
-  unnumbered in the app, so `tap` gives them attempt-wide `e1`, `e2`, … ids instead. They
-  render in italics with a parenthesized label.
-- `cy.intercept` **registration** rows have no id at all: routes are not commands. They show
-  up in the `ROUTES` table.
-- A dash prefix on the name (`-type`, `-assert`) means the command was chained off the
-  previous subject — a child command.
-
-Hook sections are numbered independently and each carries its own id — `BEFORE ALL · h1`,
-`BEFORE EACH · h2` — so the same row number appears in several sections. If an unqualified
-number matches rows in two hooks and not in the test body, the command fails and names the
-candidates:
-
-```
-That command id matches more than one row of the test.
-
-"1" matches:
-
-  h1:1 (before all)
-  h2:1 (before each)
-```
-
-Re-run with the qualified id (`-c h2:1`).
-
-### Reading the log to verify a spec you just wrote
-
-The command log is not only a post-mortem. A passing test can pass for the wrong reason — an
-assertion that read a different subject than you intended, a `cy.get()` that matched something
-else, a stubbed route that never matched and let the real request through. The log shows each
-command's message (the arguments and the yielded subject), each assertion as it actually read
-(`expected <li> to have text Pay electric bill`), and the ROUTES table with per-route match
-counts. After writing or changing a spec, read `reporter --test-id <id>` and check that story
-against what you meant — a route with `#` of `-` never matched, and an assertion phrased against
-an unexpected subject is a test that will not catch the regression it was written for.
-
-## `command` — one row, top to bottom
+## Inspect one command row
 
 ```bash
 npx cypress tap command --test-id r4 --command-id 5
 npx cypress tap command -t r4 -c h1:3 -a 1
 ```
 
-Gives the row itself under its section heading, then the panels available for that command:
-network detail, DOM snapshots you can pin, console properties, mouse events, and an error when
-present. Panels are command-dependent; do not assume every row has the same set.
+Depending on the row, output can include network details, DOM snapshots, console properties,
+mouse events, and an error. `SNAPSHOTS` identifies whether the row can be pinned.
 
-```
-TEST BODY
-✖  5  wait  @login  @login  failed
+### Console-property depth and JSON
 
-NETWORK
-  METHOD  POST
-  URL     /api/session
-  STATUS  401
-  ALIAS   @login
+- Default human output summarizes nested and long values.
+- `--depth <n>` or `--depth all` expands nesting for human output.
+- `--json` returns the raw result and requests complete console properties.
 
-SNAPSHOTS (2)
-  #  NAME    TIME
-  1  before  10:42:21.104
-  2  after   10:42:25.339
-
-CONSOLE PROPS
-  Command   wait
-  Yielded   {5 keys}
-  Request   {4 keys}
-  Response  {status: 401, body: {…}, headers: {12 keys}}
-  3 sections collapsed — open all of it with --depth all
-```
-
-`SNAPSHOTS` is the answer to "can I pin this?" — an empty panel means there is nothing to
-pin (the command captured none, or the driver has since evicted this test's details from
-memory per `numTestsKeptInMemory`).
-
-A failed row also carries an `ERROR` panel, and a row whose payload the driver gave nothing
-for reads `(nothing here)`:
-
-```
-✖  4  -click  {timeout: 1000}  failed
-
-SNAPSHOTS (2)
-  #  NAME    TIME
-  1  before  10:45:51.832
-  2  after   10:45:52.825
-
-CONSOLE PROPS
-  (nothing here)
-
-ERROR
-  [1,414 characters withheld — pass --json to include it]
-```
-
-Click rows can also include a `MOUSE EVENTS` panel after `CONSOLE PROPS`. It lists the browser
-mouse-event sequence produced by the action and may contain several rows even for one Cypress
-`click` command. Its presence is normal and does not imply a failure; an `ERROR` panel follows
-it when the command failed.
-
-### Console props depth
-
-Console properties have no bounded shape — a `cy.request` row carries its matcher, request,
-response and every header. The renderer therefore opens **collapsed**: about three levels,
-and any section too long to take in at a glance reads as `{n keys}` / `[n items]`.
-
-- `--depth <n>` expands to `n` levels and lifts the length budget (you asked for levels).
-- `--depth all` expands everything.
-- `--json` returns every property in full, however long — the one flag `command` treats as
-  changing the *result*, not just the rendering.
-
-**`--depth` and `--json` do different jobs, and `--depth` cannot substitute.** `--depth`
-expands *nesting*; a single long string stays withheld —
-`[1,414 characters withheld — pass --json to include it]` renders identically under
-`--depth all` (verified byte-for-byte). Only `--json` returns it.
-
-**Under `--json`, a failing row's error is at `consoleProps.error`** — there is no top-level
-`error` key on a `command` result, whose keys are `id`, `name`, `message`, `state`, `type`,
-`hook`, `snapshots`, `consoleProps`. This is easy to get wrong because the human rendering
-puts the error under its own `ERROR` heading *below* a `CONSOLE PROPS  (nothing here)` line, so
-the structure it implies is the opposite of the structure you must parse:
+`--depth` does not reveal withheld long strings; use `--json`. Redirect JSON to a file because
+command and test payloads can be large:
 
 ```bash
-npx cypress tap command -t r4 -c 3 --json > /tmp/cmd.json || exit 1
-node -pe "require('/tmp/cmd.json').consoleProps.error"     # not .error
-``` Shorter values are clamped to the terminal width in
-the human view, with a trailing `…`; `--json` never clamps.
-
-**Because `--json` never clamps, redirect large results to a file.** `reporter --test-id
---json` on one ordinary test of a chrome-heavy app measured 481 KB, and neither `reporter` nor
-`command` has a `-m` to cap it. Treat that number as a property of the app rather than of the
-command — the same read against a small static page measured 800 bytes. Redirect either way;
-the point is to find out by measuring, not to predict. The shell preserves a pipe or command
-substitution, but sending that much output through an agent's captured terminal output wastes
-context and may hit the surrounding tool's display limits. A file keeps the payload intact and
-out of the transcript:
-
-```bash
-npx cypress tap reporter --test-id r4 --json > /tmp/test.json || exit 1
-node -e "const v=require('/tmp/test.json'); …"
+npx cypress tap command -t r4 -c 3 --json > .tap-command.json
+node -p "require('./.tap-command.json').consoleProps.error"
 ```
 
-**Command logs keep growing after the run ends.** An idle app goes on issuing background
-requests that append to the last test's log — three consecutive reads of the same finished test
-measured 481 KB, 504 KB, then 535 KB. Reproduced deliberately against a page fetching every
-700ms: the same finished test read 2.8 KB, 8.9 KB, then 14.1 KB over 12 seconds, its row count
-going 8 → 23 → 36. The growth is background traffic, not test activity. Do not treat the last
-row as where the test stopped, and do not compare sizes across reads to infer that something
-changed.
-
-Event rows are addressable here too, and are often the most informative: `command -t r8 -c e1`
-on an `xhr` row gives its `NETWORK` panel (method, URL, indicator, stubbed, alias), `request`
-and `response` snapshots, and the matched `cy.intercept()` matcher in its console props.
+Check the first command's exit code before parsing. A failing command's serialized error is
+under `consoleProps.error`, not a top-level `error` field.

--- a/skills/cypress-tap/references/reading-results.md
+++ b/skills/cypress-tap/references/reading-results.md
@@ -1,0 +1,287 @@
+# Reading results: `reporter` and `command`
+
+These two reproduce the Cypress app's reporter panel in the terminal. Both are readable once
+the lifecycle reaches `running` — you do not have to wait for a verdict (unlike the app reads
+in `reading-the-app.md`). During `loading`, before Mocha starts, they report
+`SPEC_NOT_STARTED`; before any spec has ever run they report "No spec has run yet."
+
+## `specs` — what is runnable
+
+```bash
+npx cypress tap specs
+```
+
+```
+SPECS (3)
+  cypress/e2e/login.cy.ts     2 hours ago
+  cypress/e2e/cart.cy.ts      yesterday
+  cypress/e2e/search.cy.ts    3 days ago
+```
+
+Most recently modified first, which usually puts the spec you are working on at the top.
+Paths are POSIX and project-relative — exactly the form `run` wants. Only the **open
+testing type** is listed; a spec that exists but is missing here is outside the project's
+`specPattern`.
+
+`--json` adds `lastModifiedTimestamp` for sorting; the human view shows git's relative
+phrasing only.
+
+## `run` — start or rerun
+
+```bash
+npx cypress tap run cypress/e2e/login.cy.ts
+```
+
+```
+▶ cypress/e2e/login.cy.ts
+
+  testing type  e2e
+  browser       Chrome
+```
+
+That output confirms what was *launched*, not what happened. Poll `status` for the outcome
+(see `session-lifecycle.md`). Rerunning the same path is how you re-execute after editing
+either the spec or the app.
+
+A build failure reaches a `failed` verdict before tests exist. In that case `reporter` is an
+empty run and the useful diagnostic is `status.error`, which carries the bundler or compile
+failure.
+
+## `reporter` — the spec overview
+
+With no `--test-id`, you get the header stats plus every suite and test, each with the **test
+id** the other commands take:
+
+```bash
+npx cypress tap reporter
+```
+
+```
+cypress/e2e/login.cy.ts  (started at 10:42:19 AM)
+✓ 4  ✖ 1  ○ --  01:07
+
+Login > form
+   r3  ✓ shows validation errors    412ms
+   r4  ✖ submits valid credentials  2.1s
+   r5  ○ remembers the user         (2 attempts)
+```
+
+Test ids are the runner's own (`r3`, `r4`, …). Suite sections are the full suite path joined
+with ` > `, so titles can be pasted straight into a case-sensitive search. A retried test
+shows its attempt count and lists each attempt underneath — captured from a live run of a
+test configured with `{ retries: 2 }`:
+
+```
+tap skill check
+   r3  ✖ retries then fails  24ms  (3 attempts)
+         ✖ attempt 1  46ms
+         ✖ attempt 2  16ms
+         ✖ attempt 3  24ms
+```
+
+`--attempt` then selects one (1-based, attempt 1 = the first run); out of range, the failure
+names how many exist: *"Looked for `--attempt` 4. Test "r3" has 3 attempts."*
+
+## `reporter --test-id` — one test in full
+
+```bash
+npx cypress tap reporter --test-id r4
+npx cypress tap reporter --test-id r4 --attempt 1   # an earlier retry
+```
+
+This is the whole panel for one attempt: the `cy.session`s it used, its spies/stubs, its
+`cy.intercept` routes, the complete command log split into hook sections, and the error with
+its code frame when it failed.
+
+A failing hook may attach its error to the affected test while leaving the command log empty
+because no Cypress command ran. Read the test's error panel before assuming an empty log means
+the failure details were lost.
+
+```
+✖ Login > form > submits valid credentials  failed
+
+ROUTES (1)
+  METHOD  MATCHER          STUBBED  ALIAS  #
+  POST    **/api/session   yes      login  1
+
+BEFORE EACH · h1
+   1  visit   /login
+
+TEST BODY · r4
+   1  get     [data-cy=email]
+   2  -type   user@example.com
+   3  get     [data-cy=submit]
+   4  -click
+   5  wait    @login  @login
+   6  assert  expected '/login' to equal '/dashboard'  ✖
+
+✖ AssertionError
+  Timed out retrying after 4000ms: expected '/login' to equal '/dashboard'
+
+  cypress/e2e/login.cy.ts:24:31
+    22 |     cy.get('[data-cy=submit]').click()
+    23 |     cy.wait('@login')
+  > 24 |     cy.location('pathname').should('eq', '/dashboard')
+       |                                   ^
+```
+
+`--attempt` is 1-based and requires `--test-id`; omit it for the latest attempt.
+
+### Command ids
+
+The number in the left column is the **command id** that `command` and `pin` take. Read them
+carefully — the numbering is per hook section, so it restarts:
+
+- A plain number (`5`) resolves to the **test body** first, then to a unique match elsewhere.
+- Qualify it as `<hookId>:<number>` (`h1:3`) to target a hook row directly. The hook id is
+  printed in the section heading — `BEFORE EACH · h1`, and for the test's own commands the
+  section is headed by the test id itself (`TEST BODY · r4`), so `-c r4:2` also works.
+- Event and system rows — `xhr`, `fetch`, uncaught exceptions, driver annotations — are
+  unnumbered in the app, so `tap` gives them attempt-wide `e1`, `e2`, … ids instead. They
+  render in italics with a parenthesized label.
+- `cy.intercept` **registration** rows have no id at all: routes are not commands. They show
+  up in the `ROUTES` table.
+- A dash prefix on the name (`-type`, `-assert`) means the command was chained off the
+  previous subject — a child command.
+
+Hook sections are numbered independently and each carries its own id — `BEFORE ALL · h1`,
+`BEFORE EACH · h2` — so the same row number appears in several sections. If an unqualified
+number matches rows in two hooks and not in the test body, the command fails and names the
+candidates:
+
+```
+That command id matches more than one row of the test.
+
+"1" matches:
+
+  h1:1 (before all)
+  h2:1 (before each)
+```
+
+Re-run with the qualified id (`-c h2:1`).
+
+### Reading the log to verify a spec you just wrote
+
+The command log is not only a post-mortem. A passing test can pass for the wrong reason — an
+assertion that read a different subject than you intended, a `cy.get()` that matched something
+else, a stubbed route that never matched and let the real request through. The log shows each
+command's message (the arguments and the yielded subject), each assertion as it actually read
+(`expected <li> to have text Pay electric bill`), and the ROUTES table with per-route match
+counts. After writing or changing a spec, read `reporter --test-id <id>` and check that story
+against what you meant — a route with `#` of `-` never matched, and an assertion phrased against
+an unexpected subject is a test that will not catch the regression it was written for.
+
+## `command` — one row, top to bottom
+
+```bash
+npx cypress tap command --test-id r4 --command-id 5
+npx cypress tap command -t r4 -c h1:3 -a 1
+```
+
+Gives the row itself under its section heading, then the panels available for that command:
+network detail, DOM snapshots you can pin, console properties, mouse events, and an error when
+present. Panels are command-dependent; do not assume every row has the same set.
+
+```
+TEST BODY
+✖  5  wait  @login  @login  failed
+
+NETWORK
+  METHOD  POST
+  URL     /api/session
+  STATUS  401
+  ALIAS   @login
+
+SNAPSHOTS (2)
+  #  NAME    TIME
+  1  before  10:42:21.104
+  2  after   10:42:25.339
+
+CONSOLE PROPS
+  Command   wait
+  Yielded   {5 keys}
+  Request   {4 keys}
+  Response  {status: 401, body: {…}, headers: {12 keys}}
+  3 sections collapsed — open all of it with --depth all
+```
+
+`SNAPSHOTS` is the answer to "can I pin this?" — an empty panel means there is nothing to
+pin (the command captured none, or the driver has since evicted this test's details from
+memory per `numTestsKeptInMemory`).
+
+A failed row also carries an `ERROR` panel, and a row whose payload the driver gave nothing
+for reads `(nothing here)`:
+
+```
+✖  4  -click  {timeout: 1000}  failed
+
+SNAPSHOTS (2)
+  #  NAME    TIME
+  1  before  10:45:51.832
+  2  after   10:45:52.825
+
+CONSOLE PROPS
+  (nothing here)
+
+ERROR
+  [1,414 characters withheld — pass --json to include it]
+```
+
+Click rows can also include a `MOUSE EVENTS` panel after `CONSOLE PROPS`. It lists the browser
+mouse-event sequence produced by the action and may contain several rows even for one Cypress
+`click` command. Its presence is normal and does not imply a failure; an `ERROR` panel follows
+it when the command failed.
+
+### Console props depth
+
+Console properties have no bounded shape — a `cy.request` row carries its matcher, request,
+response and every header. The renderer therefore opens **collapsed**: about three levels,
+and any section too long to take in at a glance reads as `{n keys}` / `[n items]`.
+
+- `--depth <n>` expands to `n` levels and lifts the length budget (you asked for levels).
+- `--depth all` expands everything.
+- `--json` returns every property in full, however long — the one flag `command` treats as
+  changing the *result*, not just the rendering.
+
+**`--depth` and `--json` do different jobs, and `--depth` cannot substitute.** `--depth`
+expands *nesting*; a single long string stays withheld —
+`[1,414 characters withheld — pass --json to include it]` renders identically under
+`--depth all` (verified byte-for-byte). Only `--json` returns it.
+
+**Under `--json`, a failing row's error is at `consoleProps.error`** — there is no top-level
+`error` key on a `command` result, whose keys are `id`, `name`, `message`, `state`, `type`,
+`hook`, `snapshots`, `consoleProps`. This is easy to get wrong because the human rendering
+puts the error under its own `ERROR` heading *below* a `CONSOLE PROPS  (nothing here)` line, so
+the structure it implies is the opposite of the structure you must parse:
+
+```bash
+npx cypress tap command -t r4 -c 3 --json > /tmp/cmd.json || exit 1
+node -pe "require('/tmp/cmd.json').consoleProps.error"     # not .error
+``` Shorter values are clamped to the terminal width in
+the human view, with a trailing `…`; `--json` never clamps.
+
+**Because `--json` never clamps, redirect large results to a file.** `reporter --test-id
+--json` on one ordinary test of a chrome-heavy app measured 481 KB, and neither `reporter` nor
+`command` has a `-m` to cap it. Treat that number as a property of the app rather than of the
+command — the same read against a small static page measured 800 bytes. Redirect either way;
+the point is to find out by measuring, not to predict. The shell preserves a pipe or command
+substitution, but sending that much output through an agent's captured terminal output wastes
+context and may hit the surrounding tool's display limits. A file keeps the payload intact and
+out of the transcript:
+
+```bash
+npx cypress tap reporter --test-id r4 --json > /tmp/test.json || exit 1
+node -e "const v=require('/tmp/test.json'); …"
+```
+
+**Command logs keep growing after the run ends.** An idle app goes on issuing background
+requests that append to the last test's log — three consecutive reads of the same finished test
+measured 481 KB, 504 KB, then 535 KB. Reproduced deliberately against a page fetching every
+700ms: the same finished test read 2.8 KB, 8.9 KB, then 14.1 KB over 12 seconds, its row count
+going 8 → 23 → 36. The growth is background traffic, not test activity. Do not treat the last
+row as where the test stopped, and do not compare sizes across reads to infer that something
+changed.
+
+Event rows are addressable here too, and are often the most informative: `command -t r8 -c e1`
+on an `xhr` row gives its `NETWORK` panel (method, URL, indicator, stubbed, alias), `request`
+and `response` snapshots, and the matched `cy.intercept()` matcher in its console props.

--- a/skills/cypress-tap/references/reading-the-app.md
+++ b/skills/cypress-tap/references/reading-the-app.md
@@ -1,235 +1,124 @@
-# Reading the app under test: `dom`, `aria`, `inspect`, `pin`
+# Reading the app under test: `dom`, `aria`, `inspect`, and `pin`
 
-These four read the actual page inside the Cypress runner — the app your tests drive, not the
-Cypress UI. They serve two jobs equally: **authoring** (discover what is on the page, and which
-queries and selectors will work, before writing a command) and **debugging** (see what the app
-looked like when something failed).
+These commands read the app frame, not the Cypress UI.
 
-## They need a settled run
+## Wait for a settled run
 
-All four refuse unless the selected spec has reached `passed` or `failed`:
+`dom`, `aria`, and `inspect` require a `passed` or `failed` run. Creating a pin requires
+retained snapshots and is refused while a spec is running. These checks are not synchronization:
+immediately after `run` dispatch, the previous verdict and page can remain readable. Wait for
+a fresh `startedAt` and matching `spec` first.
 
-- **while `loading`** → `SPEC_NOT_STARTED`. The spec is selected but Mocha has not started.
-- **while `running`** → "The spec … is currently running." The page is in flux (commands
-  executing, snapshots swapping, navigation in progress), so any read would capture a
-  transient state.
-- **before any spec has run** → "No spec has run yet." There is no app under test yet, only
-  the runner shell.
+A terminal verdict does not prove that the live frame still shows useful app content. Before
+concluding that expected content is absent, check a known app anchor or inspect `body`. If the
+frame is blank after a trailing pending/skipped test, pin a snapshot from the last executed
+test, read it, then clear the pin.
 
-So the loop is always: `run` → poll `status` until a verdict with a fresh `startedAt` → read.
-
-**The refusal is a backstop, not a synchronization primitive.** In the window between `run`
-returning and the new run actually starting, the lifecycle still reports the previous
-verdict — so a read in that window **succeeds, exits `0`, and describes the previous run's
-page**. Confirmed against a live session: with the app sitting on the network-requests page,
-`run`ning a different spec and immediately reading `.network-btn` returned that button.
-Whether you get the stale page or the "currently running" refusal is a matter of timing, and
-short specs can even finish between two calls (each invocation costs about a second). Wait
-for the changed `startedAt`; do not lean on the refusal.
-
-**A verdict does not guarantee that the live frame still contains the app.** Reproduced with
-a passing spec whose final test was `it.skip`: after the green verdict, the runner showed its
-blank placeholder and `aria`, `dom`, and `inspect` all exited `0` with plausible absence
-results. Removing the trailing pending test restored live reads; pinning a snapshot from the
-last real command exposed the correct page immediately.
-
-Before concluding that an expected element is absent, sanity-check a known app anchor (or read
-`body` and confirm it is your app). If the run ended on a pending/skipped test and the live frame
-is blank, use `command` to find a snapshot from the last executed test, `pin` it, perform the
-reads, then `pin --clear`. Do not interpret a successful read of the blank runner placeholder
-as application state.
-
-## `dom` — the page as HTML
+## `dom`: HTML and text
 
 ```bash
-npx cypress tap dom                                  # <body> and its subtree
-npx cypress tap dom --selector html                  # the whole document
-npx cypress tap dom -e '[data-cy=cart-item]'         # one element's subtree
-npx cypress tap dom -e '#app' -m 80000               # raise the character cap
+npx cypress tap dom
+npx cypress tap dom --selector 'form'
+npx cypress tap dom --selector html
+npx cypress tap dom --selector '#app' --max-chars 80000
 ```
 
-Output is the element's `outerHTML`, dedented to the margin, and nothing else — no framing,
-so it pipes cleanly. Capped at **30 000 characters** browser-side (`-m/--max-chars`); a clipped
-result ends with `(output truncated)`. Prefer narrowing the selector over raising the cap.
+The default selector is `body`; `html` includes the document head. Output is the selected
+element's `outerHTML`. The default 30,000-character cap is browser-side, and truncated output
+is marked. Cypress instrumentation in `<head>` can consume that entire cap for `html` before
+app markup appears. Never infer absence from truncated output: narrow the selector or raise the
+cap.
 
-Treat truncation as a correctness hazard, not just a display limit. A chrome-heavy app can
-spend the entire budget on nav and sidebar markup before reaching the region you asked about,
-and even `--selector '#main'` can clip. Searching a clipped result then reports text as absent
-when it was only cut off — so **never conclude an element or string is missing from a
-truncated read**. Check for the marker first, then narrow to the smallest enclosing element
-(or raise `-m`) and read again.
+`outerHTML` reports attributes, not current DOM properties. For example, after typing into an
+input, `dom` may still show its original `value="1"` attribute even though its live value is
+`3`. Use `aria` to read the current value of an accessible form control.
 
-`--selector html` is how you get `<head>`; the default `body` skips the script and style text
-that would otherwise dominate the read.
-
-## `aria` — the accessibility tree
+## `aria`: semantic structure
 
 ```bash
-npx cypress tap aria                                 # from <body>
-npx cypress tap aria -e '[role=dialog]'              # subtree at an element
-npx cypress tap aria -m 500                          # raise the node cap
+npx cypress tap aria
+npx cypress tap aria --selector '[role=dialog]'
+npx cypress tap aria --max-nodes 500
 ```
 
-```
-main
-  heading  Your cart
-  list
-    listitem
-      link  Blue shirt
-      button  Remove  [disabled]
-    listitem
-      link  Red hat
-      button  Remove
-  textbox  Promo code = SAVE10  [invalid]
-  button  Checkout
-```
+`aria` returns a compact accessibility tree of roles, accessible names, values, and states.
+The default root is `body` and the default cap is 200 nodes. Use it to understand controls and
+semantic structure; use `dom` for exact body text.
 
-One line per node, indented by depth: role, accessible name, `= value` for value-bearing
-controls, and notable states in brackets (`focused`, `disabled`, `required`, `invalid`,
-`checked`, `expanded`, `selected`, `pressed`, `readonly`, `hidden`, `modal`, `busy`).
+The tree is filtered to semantic roles, but the filter is incomplete: Chromium's internal
+`ListMarker` and `LabelText` roles leak through as bare, nameless rows and count against
+`--max-nodes`. Ignore them when reading structure, and expect the effective budget to run out
+sooner than 200 nodes on list- or form-heavy pages.
 
-Most structural and text-only roles are dropped, including `StaticText`, `generic`,
-`paragraph`, `InlineTextBox`, `LineBreak`, and `none`, which is what makes the tree compact.
-The filtering is not exhaustive: unnamed `LabelText` nodes can still appear as bare
-`LabelText` lines. **`aria` is not how you read body copy.** Use `dom` for text content and
-`aria` for structure, semantics and control state. Capped at **200 nodes**
-(`-m/--max-nodes`).
+Accessibility nodes do not necessarily expose descendant text. In particular, a live region
+such as `role="status"` may appear as a bare node even while it contains a toast or status
+message, and a `<label>` may surface as a bare `LabelText` row instead of its text. Use `dom`
+when verifying live-region, toast, status, or label text. For form-control values, use `aria`.
 
-This is the best first read for "what can a user do on this page right now", and for
-designing accessibility-aware queries when the project uses commands such as Cypress Testing
-Library's role and label queries. Cypress's built-in `cy.get()` takes a CSS selector.
-
-## `inspect` — one element in detail
+## `inspect`: one element in detail
 
 ```bash
-npx cypress tap inspect -e '[data-cy=submit]'
+npx cypress tap inspect --selector '[data-cy=submit]'
 ```
 
-```
-ATTRIBUTES (3)
-  data-cy  submit
-  class    btn btn-primary
-  disabled
+`--selector` is required. Output includes attributes, curated computed styles, and box geometry.
+It includes an accessibility section when the browser exposes a node; hidden or ignored elements
+may omit that section. It helps explain visibility and interaction problems, but does not
+reproduce Cypress's full actionability algorithm.
 
-ACCESSIBILITY
-  role    button
-  name    Place order
-  states  disabled
+The element's tag name is not in the human output, even though `inspect --help` lists it and
+`--json` carries it as `tag`. Read the tag from `dom`, or from `inspect --json`. The
+accessibility section here is also unfiltered, so a semantically empty element reports
+`role generic` where `aria` drops the node entirely — a `role` from `inspect` is not evidence of
+meaningful semantics.
 
-BOX
-  x 412   y 780   width 148   height 44
+Do not use `inspect` to read a form control's live value. Its attributes can retain the initial
+HTML value, and its accessibility section may omit a value that `aria` exposes. Use `aria` for
+the current value.
 
-STYLES (24)
-  display        inline-flex
-  visibility     visible
-  opacity        1
-  pointer-events none
-  …
-```
+## Selectors must identify one element
 
-`--selector` is **required** here. The style list is a curated ~24 properties that answer
-"why does it look or behave this way": layout and positioning, box metrics, visibility,
-color and type, `z-index`, `overflow`, `pointer-events`, `cursor`. It exposes useful factors
-behind "the click did nothing" and "the assertion says it is not visible", but Cypress still
-decides full actionability, including coverage, animation, and detachment.
+All three readers require exactly one selected element:
 
-## One element, or nothing
+- One match: return the read.
+- Multiple matches without `--at`: exit `1` and list candidate selectors.
+- Multiple matches with `--at <index>`: read the 0-based match.
+- No matches: `dom` and `inspect` return `found:false` with exit `0`; `aria` returns an empty
+  tree.
 
-`dom`, `aria` and `inspect` all require the selector to match **exactly one** element. A
-selector matching more is refused — no silent first-match — and answered with the matches:
+Because an empty `aria` result can mean either no match or no accessibility node, use `dom` or
+`inspect` to establish element absence. In JSON, only `inspect` echoes the missed selector;
+`dom` returns only `{"found":false}`.
 
-```
-⚠ selector 'li' matched 26 elements but must be unique
-provide --at with an index to select an element from the list or update the selector.
-index  selector
-0      '.dropdown'
-1      '.dropdown-menu > :nth-child(1)'
-…
-9      '.dropdown-menu > :nth-child(9)'
+The ambiguity response derives candidate selectors for only a bounded number of matches, but
+`--at` can select any valid index. A missing candidate means no unique selector was derived;
+prefer a semantic query or add a stable `data-*` hook.
 
-showing the first 10 of 26 matches — --at takes any index up to 25.
-```
+## `pin`: inspect a command snapshot
 
-Exit code is `1`, and the list is on stdout. Recover either way: re-run with a unique selector
-from the table, or with `--at <index>`. **`--at` here is 0-based** and indexes
-`document.querySelectorAll(selector)`.
-
-A selector matching nothing is different: the command succeeds with exit `0`. `dom` and
-`inspect` report `found:false`, meaning the requested element is absent. `aria` instead returns
-an empty tree both when the selector misses and when the matched element has no accessibility
-node, so use `dom` or `inspect` to establish absence. Do not restart or retry the same selector
-unless app state is expected to change.
-
-Only the first 10 matches get a derived selector (deriving one is expensive on a large page),
-and the output says so; `--at` still accepts any index up to `count - 1`. A `-` in the selector column means no unique
-CSS selector could be derived for that match.
-
-## `pin` — read the app as it was at an earlier command
-
-The live frame only ever shows the *final* state of the run. `pin` puts a command's captured
-DOM snapshot into that frame, so `dom`, `aria` and `inspect` then read **that moment**
-instead.
+The live frame shows the run's final state. `pin` replaces it with a DOM snapshot captured on
+a reporter command:
 
 ```bash
-npx cypress tap pin --test-id r4 --command-id 5          # last snapshot of the command
-npx cypress tap pin -t r4 -c 5 --at before               # by snapshot name
-npx cypress tap pin -t r4 -c 5 --at 1                    # by 1-based position
-npx cypress tap pin --clear                              # release, restore the live page
+npx cypress tap command --test-id r4 --command-id 5
+npx cypress tap pin --test-id r4 --command-id 5
+npx cypress tap pin -t r4 -c 5 --at before
+npx cypress tap pin -t r4 -c 5 --at 1
+npx cypress tap pin --clear
 ```
 
-```
-⚲ PINNED - (2/2) after
-TEST BODY · r4
-   5  wait  @login  @login
-```
+Get test and command ids from `reporter`. For `pin`, `--at` is a snapshot name or 1-based
+index; this differs from the readers' 0-based element index. With no `--at`, `pin` chooses the
+last snapshot.
 
-- `--test-id` and `--command-id` are both required (unless `--clear`); get them from
-  `reporter` — see `reading-results.md`.
-- **`--at` on `pin` is a snapshot name or a 1-based index** — not the 0-based element index
-  the reads use. `command --test-id … --command-id …` lists a row's snapshots by both.
-- Re-running `pin` on the already-pinned command switches snapshots without releasing.
-- `status` reports the active pin, so a later read never surprises you.
-- Always `pin --clear` when done — otherwise every later `dom`/`aria`/`inspect` silently
-  describes the pinned past.
+While pinned, `dom`, `aria`, and `inspect` read the snapshot. Always run `pin --clear` when
+finished. Clearing when nothing is pinned—or while a spec is running—still exits `0` and
+reports `cleared:false`. Human output may call this `FAILED TO CLEAR PIN`; despite that wording,
+it is a benign no-op, so do not retry it as an error. Pins created manually in the Cypress
+reporter are visible to `status` and can also be cleared by `tap`.
 
-Snapshots are captured in open mode only, and kept only for the most recent tests
-(`numTestsKeptInMemory`). "That command has no DOM snapshot to pin" means the row captured
-none or its test was evicted — rerun the spec for fresh snapshots, or raise
-`numTestsKeptInMemory`.
-
-A pinned snapshot is a DOM snapshot: styling and structure are faithful, but nothing runs.
-No scripts, no network, no live state.
-
-Elements the driver interacted with carry a `data-cypress-el="true"` attribute in snapshots.
-That is Cypress instrumentation, not application markup — `inspect` will list it, and it is
-not a finding.
-
-### The failure-diagnosis loop
-
-The full loop — failing ids from `--json`, `reporter --test-id`, `command`, then `pin` +
-`inspect` — is in SKILL.md under Recipes. The part that belongs here: `pin` is what turns a
-post-mortem into an inspection, because it puts the app back into the state the failing
-command saw. Without it, `dom`/`aria`/`inspect` can only ever describe the end of the run.
-
-## Harvesting selectors while authoring
-
-There is no CLI command that lists selectors on demand — the session has an internal
-`resolve-selector` command, but the CLI does not register hidden commands, so
-`cypress tap resolve-selector …` answers `Unknown command`. The ambiguity report *is* the
-selector-discovery tool, and you reach it by reading with a deliberately loose selector:
-
-```bash
-npx cypress tap inspect --selector 'li'      # or dom / aria — any of the three
-```
-
-You get a unique selector for each of the first 10 matches, a total count, and `-` for any match
-no unique selector could be derived for. Exit code is `1`, which is expected here — you invoked
-it for the list, not for the read. Uses while authoring:
-
-- Turn an element you spotted in `dom`/`aria` into a selector that resolves to exactly one node.
-- See the shape of a repeated region (list items, table rows, cards) in one call.
-- Learn that the resolver could not derive a unique selector, in which case prefer a semantic
-  query or add a stable `data-*` hook instead of inventing a fragile CSS path.
-
-Narrow the input if it matches hundreds: derivation is capped at 10 matches, and `--at` still
-reads any index beyond that.
+Snapshots are available only for retained open-mode tests. If a row has no snapshots or its
+details were evicted according to `numTestsKeptInMemory`, rerun the spec or choose another row.
+A snapshot is static DOM: scripts and network activity do not run.
+An interacted element may carry `data-cypress-el="true"` in a snapshot; that is Cypress
+instrumentation, not application markup.

--- a/skills/cypress-tap/references/reading-the-app.md
+++ b/skills/cypress-tap/references/reading-the-app.md
@@ -1,0 +1,235 @@
+# Reading the app under test: `dom`, `aria`, `inspect`, `pin`
+
+These four read the actual page inside the Cypress runner — the app your tests drive, not the
+Cypress UI. They serve two jobs equally: **authoring** (discover what is on the page, and which
+queries and selectors will work, before writing a command) and **debugging** (see what the app
+looked like when something failed).
+
+## They need a settled run
+
+All four refuse unless the selected spec has reached `passed` or `failed`:
+
+- **while `loading`** → `SPEC_NOT_STARTED`. The spec is selected but Mocha has not started.
+- **while `running`** → "The spec … is currently running." The page is in flux (commands
+  executing, snapshots swapping, navigation in progress), so any read would capture a
+  transient state.
+- **before any spec has run** → "No spec has run yet." There is no app under test yet, only
+  the runner shell.
+
+So the loop is always: `run` → poll `status` until a verdict with a fresh `startedAt` → read.
+
+**The refusal is a backstop, not a synchronization primitive.** In the window between `run`
+returning and the new run actually starting, the lifecycle still reports the previous
+verdict — so a read in that window **succeeds, exits `0`, and describes the previous run's
+page**. Confirmed against a live session: with the app sitting on the network-requests page,
+`run`ning a different spec and immediately reading `.network-btn` returned that button.
+Whether you get the stale page or the "currently running" refusal is a matter of timing, and
+short specs can even finish between two calls (each invocation costs about a second). Wait
+for the changed `startedAt`; do not lean on the refusal.
+
+**A verdict does not guarantee that the live frame still contains the app.** Reproduced with
+a passing spec whose final test was `it.skip`: after the green verdict, the runner showed its
+blank placeholder and `aria`, `dom`, and `inspect` all exited `0` with plausible absence
+results. Removing the trailing pending test restored live reads; pinning a snapshot from the
+last real command exposed the correct page immediately.
+
+Before concluding that an expected element is absent, sanity-check a known app anchor (or read
+`body` and confirm it is your app). If the run ended on a pending/skipped test and the live frame
+is blank, use `command` to find a snapshot from the last executed test, `pin` it, perform the
+reads, then `pin --clear`. Do not interpret a successful read of the blank runner placeholder
+as application state.
+
+## `dom` — the page as HTML
+
+```bash
+npx cypress tap dom                                  # <body> and its subtree
+npx cypress tap dom --selector html                  # the whole document
+npx cypress tap dom -e '[data-cy=cart-item]'         # one element's subtree
+npx cypress tap dom -e '#app' -m 80000               # raise the character cap
+```
+
+Output is the element's `outerHTML`, dedented to the margin, and nothing else — no framing,
+so it pipes cleanly. Capped at **30 000 characters** browser-side (`-m/--max-chars`); a clipped
+result ends with `(output truncated)`. Prefer narrowing the selector over raising the cap.
+
+Treat truncation as a correctness hazard, not just a display limit. A chrome-heavy app can
+spend the entire budget on nav and sidebar markup before reaching the region you asked about,
+and even `--selector '#main'` can clip. Searching a clipped result then reports text as absent
+when it was only cut off — so **never conclude an element or string is missing from a
+truncated read**. Check for the marker first, then narrow to the smallest enclosing element
+(or raise `-m`) and read again.
+
+`--selector html` is how you get `<head>`; the default `body` skips the script and style text
+that would otherwise dominate the read.
+
+## `aria` — the accessibility tree
+
+```bash
+npx cypress tap aria                                 # from <body>
+npx cypress tap aria -e '[role=dialog]'              # subtree at an element
+npx cypress tap aria -m 500                          # raise the node cap
+```
+
+```
+main
+  heading  Your cart
+  list
+    listitem
+      link  Blue shirt
+      button  Remove  [disabled]
+    listitem
+      link  Red hat
+      button  Remove
+  textbox  Promo code = SAVE10  [invalid]
+  button  Checkout
+```
+
+One line per node, indented by depth: role, accessible name, `= value` for value-bearing
+controls, and notable states in brackets (`focused`, `disabled`, `required`, `invalid`,
+`checked`, `expanded`, `selected`, `pressed`, `readonly`, `hidden`, `modal`, `busy`).
+
+Most structural and text-only roles are dropped, including `StaticText`, `generic`,
+`paragraph`, `InlineTextBox`, `LineBreak`, and `none`, which is what makes the tree compact.
+The filtering is not exhaustive: unnamed `LabelText` nodes can still appear as bare
+`LabelText` lines. **`aria` is not how you read body copy.** Use `dom` for text content and
+`aria` for structure, semantics and control state. Capped at **200 nodes**
+(`-m/--max-nodes`).
+
+This is the best first read for "what can a user do on this page right now", and for
+designing accessibility-aware queries when the project uses commands such as Cypress Testing
+Library's role and label queries. Cypress's built-in `cy.get()` takes a CSS selector.
+
+## `inspect` — one element in detail
+
+```bash
+npx cypress tap inspect -e '[data-cy=submit]'
+```
+
+```
+ATTRIBUTES (3)
+  data-cy  submit
+  class    btn btn-primary
+  disabled
+
+ACCESSIBILITY
+  role    button
+  name    Place order
+  states  disabled
+
+BOX
+  x 412   y 780   width 148   height 44
+
+STYLES (24)
+  display        inline-flex
+  visibility     visible
+  opacity        1
+  pointer-events none
+  …
+```
+
+`--selector` is **required** here. The style list is a curated ~24 properties that answer
+"why does it look or behave this way": layout and positioning, box metrics, visibility,
+color and type, `z-index`, `overflow`, `pointer-events`, `cursor`. It exposes useful factors
+behind "the click did nothing" and "the assertion says it is not visible", but Cypress still
+decides full actionability, including coverage, animation, and detachment.
+
+## One element, or nothing
+
+`dom`, `aria` and `inspect` all require the selector to match **exactly one** element. A
+selector matching more is refused — no silent first-match — and answered with the matches:
+
+```
+⚠ selector 'li' matched 26 elements but must be unique
+provide --at with an index to select an element from the list or update the selector.
+index  selector
+0      '.dropdown'
+1      '.dropdown-menu > :nth-child(1)'
+…
+9      '.dropdown-menu > :nth-child(9)'
+
+showing the first 10 of 26 matches — --at takes any index up to 25.
+```
+
+Exit code is `1`, and the list is on stdout. Recover either way: re-run with a unique selector
+from the table, or with `--at <index>`. **`--at` here is 0-based** and indexes
+`document.querySelectorAll(selector)`.
+
+A selector matching nothing is different: the command succeeds with exit `0`. `dom` and
+`inspect` report `found:false`, meaning the requested element is absent. `aria` instead returns
+an empty tree both when the selector misses and when the matched element has no accessibility
+node, so use `dom` or `inspect` to establish absence. Do not restart or retry the same selector
+unless app state is expected to change.
+
+Only the first 10 matches get a derived selector (deriving one is expensive on a large page),
+and the output says so; `--at` still accepts any index up to `count - 1`. A `-` in the selector column means no unique
+CSS selector could be derived for that match.
+
+## `pin` — read the app as it was at an earlier command
+
+The live frame only ever shows the *final* state of the run. `pin` puts a command's captured
+DOM snapshot into that frame, so `dom`, `aria` and `inspect` then read **that moment**
+instead.
+
+```bash
+npx cypress tap pin --test-id r4 --command-id 5          # last snapshot of the command
+npx cypress tap pin -t r4 -c 5 --at before               # by snapshot name
+npx cypress tap pin -t r4 -c 5 --at 1                    # by 1-based position
+npx cypress tap pin --clear                              # release, restore the live page
+```
+
+```
+⚲ PINNED - (2/2) after
+TEST BODY · r4
+   5  wait  @login  @login
+```
+
+- `--test-id` and `--command-id` are both required (unless `--clear`); get them from
+  `reporter` — see `reading-results.md`.
+- **`--at` on `pin` is a snapshot name or a 1-based index** — not the 0-based element index
+  the reads use. `command --test-id … --command-id …` lists a row's snapshots by both.
+- Re-running `pin` on the already-pinned command switches snapshots without releasing.
+- `status` reports the active pin, so a later read never surprises you.
+- Always `pin --clear` when done — otherwise every later `dom`/`aria`/`inspect` silently
+  describes the pinned past.
+
+Snapshots are captured in open mode only, and kept only for the most recent tests
+(`numTestsKeptInMemory`). "That command has no DOM snapshot to pin" means the row captured
+none or its test was evicted — rerun the spec for fresh snapshots, or raise
+`numTestsKeptInMemory`.
+
+A pinned snapshot is a DOM snapshot: styling and structure are faithful, but nothing runs.
+No scripts, no network, no live state.
+
+Elements the driver interacted with carry a `data-cypress-el="true"` attribute in snapshots.
+That is Cypress instrumentation, not application markup — `inspect` will list it, and it is
+not a finding.
+
+### The failure-diagnosis loop
+
+The full loop — failing ids from `--json`, `reporter --test-id`, `command`, then `pin` +
+`inspect` — is in SKILL.md under Recipes. The part that belongs here: `pin` is what turns a
+post-mortem into an inspection, because it puts the app back into the state the failing
+command saw. Without it, `dom`/`aria`/`inspect` can only ever describe the end of the run.
+
+## Harvesting selectors while authoring
+
+There is no CLI command that lists selectors on demand — the session has an internal
+`resolve-selector` command, but the CLI does not register hidden commands, so
+`cypress tap resolve-selector …` answers `Unknown command`. The ambiguity report *is* the
+selector-discovery tool, and you reach it by reading with a deliberately loose selector:
+
+```bash
+npx cypress tap inspect --selector 'li'      # or dom / aria — any of the three
+```
+
+You get a unique selector for each of the first 10 matches, a total count, and `-` for any match
+no unique selector could be derived for. Exit code is `1`, which is expected here — you invoked
+it for the list, not for the read. Uses while authoring:
+
+- Turn an element you spotted in `dom`/`aria` into a selector that resolves to exactly one node.
+- See the shape of a repeated region (list items, table rows, cards) in one call.
+- Learn that the resolver could not derive a unique selector, in which case prefer a semantic
+  query or add a stable `data-*` hook instead of inventing a fragile CSS path.
+
+Narrow the input if it matches hundreds: derivation is capped at 10 matches, and `--at` still
+reads any index beyond that.

--- a/skills/cypress-tap/references/recipes.md
+++ b/skills/cypress-tap/references/recipes.md
@@ -6,25 +6,27 @@ assume the session is selected and the fresh-verdict polling workflow from `SKIL
 ## Author a spec against the real app
 
 `tap` can read the app only after a spec has settled. Start with a temporary probe spec that
-navigates to the state you need:
+navigates to the state you need. Create `cypress/e2e/_probe.cy.js`:
 
-```bash
-cat > cypress/e2e/_probe.cy.js <<'SPEC'
+```javascript
 it('probe', () => {
   cy.visit('/checkout')
 })
-SPEC
+```
 
-npx cypress tap run cypress/e2e/_probe.cy.js
-# Wait for a fresh verdict before reading the app.
+Run the probe using the fresh-verdict workflow in `SKILL.md`. After it reaches a matching
+`passed` or `failed` verdict, read the app:
+
+```bash
 npx cypress tap aria
 npx cypress tap dom --selector 'form'
 npx cypress tap inspect --selector '[data-cy=pay]'
 ```
 
-Read `aria` first for roles, accessible names, values, and control states. Use `dom` for exact
-text and attributes. Use `inspect` for attributes, styles, box geometry, and the accessibility
-node.
+Read `aria` first for roles, accessible names, live form-control values, and control states.
+Use `dom` for exact text—including live-region and toast text—and HTML attributes. Use
+`inspect` for attributes, styles, box geometry, and the accessibility node, but not for a
+control's live value.
 
 To discover selectors, deliberately make a broad read:
 
@@ -63,35 +65,9 @@ npx cypress tap reporter --test-id r4
 ## Hunt a flake
 
 Rerun in a bounded loop and stop on the first failure. Another run overwrites the result you
-need to diagnose.
-
-```bash
-SPEC=cypress/e2e/login.cy.ts
-for attempt in $(seq 1 10); do
-  while ! IFS='|' read -r _ before _ _ < <(tap_state); do sleep 2; done
-  npx cypress tap run "$SPEC" || { echo "dispatch failed" >&2; exit 2; }
-
-  fresh=0
-  for _ in $(seq 1 150); do
-    if IFS='|' read -r stage started_at _ ran_spec < <(tap_state); then
-      case "$stage" in
-        passed|failed)
-          [ -n "$started_at" ] && [ "$started_at" != "$before" ] && [ "$ran_spec" = "$SPEC" ] \
-            && { fresh=1; break; } ;;
-      esac
-    fi
-    sleep 2
-  done
-  [ "$fresh" -eq 1 ] || { echo "no fresh verdict on attempt $attempt" >&2; exit 2; }
-
-  echo "attempt $attempt -> $stage"
-  [ "$stage" = "failed" ] && { echo "failed on attempt $attempt"; exit 1; }
-done
-echo "no failure in 10 attempts"
-```
-
-Exit nonzero when the sought failure occurs so a supervising harness does not label the hunt
-successful. "No failure" is absence of evidence, not proof that the spec is stable.
+need to diagnose. Apply the fresh-verdict workflow before evaluating each attempt, preserve the
+first failed result, and return a nonzero outcome when the sought failure occurs. Completing the
+requested attempts without a failure is not proof that the spec is stable.
 
 If Cypress retries a test, `reporter --test-id` defaults to the latest attempt, which may pass:
 
@@ -106,15 +82,10 @@ load rather than an assertion that needs a longer timeout.
 
 ## Diagnose a failure
 
-First capture the failed test id. Guard JSON parsing because a failed command leaves stdout
-empty:
+First capture the failed test id:
 
 ```bash
-if ! out=$(npx cypress tap reporter --json); then exit 1; fi
-printf '%s' "$out" | node -pe "
-  const v = JSON.parse(require('fs').readFileSync(0))
-  const tests = [...(v.tests || []), ...(v.suites || []).flatMap(s => s.tests || [])]
-  tests.filter(t => t.state === 'failed').map(t => t.id).join(' ')"
+npx cypress tap reporter
 ```
 
 Then inspect the test, failing command, and app at that command's snapshot:
@@ -122,7 +93,7 @@ Then inspect the test, failing command, and app at that command's snapshot:
 ```bash
 npx cypress tap reporter --test-id r4
 npx cypress tap command --test-id r4 --command-id 4
-npx cypress tap command --test-id r4 --command-id 4 --json > /tmp/tap-command.json
+npx cypress tap command --test-id r4 --command-id 4 --json > .tap-command.json
 npx cypress tap pin --test-id r4 --command-id 4
 npx cypress tap inspect --selector '.action-disabled'
 npx cypress tap pin --clear
@@ -138,7 +109,8 @@ Use `command` to confirm that the row has snapshots, then `pin` it. While pinned
 
 - `aria` shows structure and control state.
 - `dom` shows markup and text.
-- `inspect` shows one element's attributes, styles, geometry, and accessibility node.
+- `inspect` shows one element's attributes, styles, geometry, and accessibility node, but may
+  omit its live form-control value.
 
 Run `pin --clear` afterward. If uncertain, `status` reports the active pin as `⚲ PINNED` in the
 human output and as `pinned` in JSON.

--- a/skills/cypress-tap/references/recipes.md
+++ b/skills/cypress-tap/references/recipes.md
@@ -68,17 +68,18 @@ need to diagnose.
 ```bash
 SPEC=cypress/e2e/login.cy.ts
 for attempt in $(seq 1 10); do
-  IFS='|' read -r _ before _ _ < <(tap_state)
+  while ! IFS='|' read -r _ before _ _ < <(tap_state); do sleep 2; done
   npx cypress tap run "$SPEC" || { echo "dispatch failed" >&2; exit 2; }
 
   fresh=0
   for _ in $(seq 1 150); do
-    IFS='|' read -r stage started_at _ ran_spec < <(tap_state)
-    case "$stage" in
-      passed|failed)
-        [ -n "$started_at" ] && [ "$started_at" != "$before" ] && [ "$ran_spec" = "$SPEC" ] \
-          && { fresh=1; break; } ;;
-    esac
+    if IFS='|' read -r stage started_at _ ran_spec < <(tap_state); then
+      case "$stage" in
+        passed|failed)
+          [ -n "$started_at" ] && [ "$started_at" != "$before" ] && [ "$ran_spec" = "$SPEC" ] \
+            && { fresh=1; break; } ;;
+      esac
+    fi
     sleep 2
   done
   [ "$fresh" -eq 1 ] || { echo "no fresh verdict on attempt $attempt" >&2; exit 2; }

--- a/skills/cypress-tap/references/recipes.md
+++ b/skills/cypress-tap/references/recipes.md
@@ -1,0 +1,143 @@
+# Recipes
+
+Read this file when authoring a spec, hunting a flake, or diagnosing a failed run. All recipes
+assume the session is selected and the fresh-verdict polling workflow from `SKILL.md` is in use.
+
+## Author a spec against the real app
+
+`tap` can read the app only after a spec has settled. Start with a temporary probe spec that
+navigates to the state you need:
+
+```bash
+cat > cypress/e2e/_probe.cy.js <<'SPEC'
+it('probe', () => {
+  cy.visit('/checkout')
+})
+SPEC
+
+npx cypress tap run cypress/e2e/_probe.cy.js
+# Wait for a fresh verdict before reading the app.
+npx cypress tap aria
+npx cypress tap dom --selector 'form'
+npx cypress tap inspect --selector '[data-cy=pay]'
+```
+
+Read `aria` first for roles, accessible names, values, and control states. Use `dom` for exact
+text and attributes. Use `inspect` for attributes, styles, box geometry, and the accessibility
+node.
+
+To discover selectors, deliberately make a broad read:
+
+```bash
+npx cypress tap inspect --selector 'form button'
+```
+
+The expected exit `1` ambiguity response lists unique selectors for the matches. A selector
+shown as `-` could not be made unique; prefer a semantic query or add a stable `data-*` hook.
+
+Grow the probe to create deeper state, then write the real spec. After it passes, read
+`reporter --test-id <id>` and verify that commands yielded the intended subjects, assertions
+read what you meant, and stubbed routes actually matched. Keep the probe until inspection is
+done: deleting or renaming the selected spec drops its in-memory results.
+
+Saving the active spec triggers Cypress's file watcher. Let that run settle before taking a
+new `startedAt` baseline and dispatching another run, or use the watcher's run as the run you
+inspect. Do not put both in flight.
+
+## Report a run
+
+After the fresh-verdict poll completes:
+
+```bash
+npx cypress tap status
+npx cypress tap reporter
+```
+
+Report the `status.results` counts. For a build failure, use `status.error`; no tests may exist.
+For a failed test, get its id from `reporter`, then read:
+
+```bash
+npx cypress tap reporter --test-id r4
+```
+
+## Hunt a flake
+
+Rerun in a bounded loop and stop on the first failure. Another run overwrites the result you
+need to diagnose.
+
+```bash
+SPEC=cypress/e2e/login.cy.ts
+for attempt in $(seq 1 10); do
+  IFS='|' read -r _ before _ _ < <(tap_state)
+  npx cypress tap run "$SPEC" || { echo "dispatch failed" >&2; exit 2; }
+
+  fresh=0
+  for _ in $(seq 1 150); do
+    IFS='|' read -r stage started_at _ ran_spec < <(tap_state)
+    case "$stage" in
+      passed|failed)
+        [ -n "$started_at" ] && [ "$started_at" != "$before" ] && [ "$ran_spec" = "$SPEC" ] \
+          && { fresh=1; break; } ;;
+    esac
+    sleep 2
+  done
+  [ "$fresh" -eq 1 ] || { echo "no fresh verdict on attempt $attempt" >&2; exit 2; }
+
+  echo "attempt $attempt -> $stage"
+  [ "$stage" = "failed" ] && { echo "failed on attempt $attempt"; exit 1; }
+done
+echo "no failure in 10 attempts"
+```
+
+Exit nonzero when the sought failure occurs so a supervising harness does not label the hunt
+successful. "No failure" is absence of evidence, not proof that the spec is stable.
+
+If Cypress retries a test, `reporter --test-id` defaults to the latest attempt, which may pass:
+
+```bash
+npx cypress tap reporter --test-id r4
+npx cypress tap reporter --test-id r4 --attempt 1
+```
+
+Read the failed attempt before editing. Re-read each failure rather than assuming it is the
+same one; fixing one flake may expose another. A moving failure site can indicate environmental
+load rather than an assertion that needs a longer timeout.
+
+## Diagnose a failure
+
+First capture the failed test id. Guard JSON parsing because a failed command leaves stdout
+empty:
+
+```bash
+if ! out=$(npx cypress tap reporter --json); then exit 1; fi
+printf '%s' "$out" | node -pe "
+  const v = JSON.parse(require('fs').readFileSync(0))
+  const tests = [...(v.tests || []), ...(v.suites || []).flatMap(s => s.tests || [])]
+  tests.filter(t => t.state === 'failed').map(t => t.id).join(' ')"
+```
+
+Then inspect the test, failing command, and app at that command's snapshot:
+
+```bash
+npx cypress tap reporter --test-id r4
+npx cypress tap command --test-id r4 --command-id 4
+npx cypress tap command --test-id r4 --command-id 4 --json > /tmp/tap-command.json
+npx cypress tap pin --test-id r4 --command-id 4
+npx cypress tap inspect --selector '.action-disabled'
+npx cypress tap pin --clear
+```
+
+Read the complete test view before assuming its last command is the cause; an uncaught-exception
+event or hook error earlier in the log may be the real failure. Always clear the pin, or later
+app reads continue to describe the past.
+
+## Inspect app state at a step
+
+Use `command` to confirm that the row has snapshots, then `pin` it. While pinned:
+
+- `aria` shows structure and control state.
+- `dom` shows markup and text.
+- `inspect` shows one element's attributes, styles, geometry, and accessibility node.
+
+Run `pin --clear` afterward. If uncertain, `status` reports the active pin as `⚲ PINNED` in the
+human output and as `pinned` in JSON.

--- a/skills/cypress-tap/references/session-lifecycle.md
+++ b/skills/cypress-tap/references/session-lifecycle.md
@@ -1,240 +1,113 @@
 # Sessions and the run lifecycle
 
-## Starting a session `tap` can drive
+## Start a compatible session
 
-`tap` never launches Cypress. Something must run `cypress open` first, in the background:
-
-```bash
-cd /path/to/project
-npx cypress open --e2e --browser electron &          # e2e
-npx cypress open --component --browser electron &    # component testing
-```
-
-Those `npx` examples assume an installed Cypress binary. When smoke-testing `tap` from the
-Cypress source monorepo, an unbuilt checkout can report `Cypress binary version: not installed`;
-run the root development launcher instead:
+`tap` drives an existing `cypress open` process; it does not start Cypress:
 
 ```bash
-yarn dev --project /path/to/project
+npx cypress open --e2e --browser electron
+npx cypress open --component --browser electron
 ```
 
-The root script wraps the development-mode gulp workflow that builds and launches Cypress;
-`npx cypress open` expects an installed binary.
+Electron, Chrome, Chromium, and Edge are supported. Firefox and WebKit are listed by
+`sessions` but refused by other commands. Ensure the configured `baseUrl` server is running
+and the chosen testing type exists in the Cypress config.
 
-Electron is the safest default — it ships with Cypress, so nothing external has to be
-installed or discoverable. Chrome, Chromium and Edge work equally well. Firefox and WebKit
-do not: `tap` drives the browser over the Chrome DevTools Protocol, so a Firefox or WebKit
-session is reported as `unsupported` and every command except `sessions` refuses it.
+The `--browser electron` examples attach a browser immediately and normally reach
+`spec not selected`; they do not normally expose `browser not selected`. If Cypress was opened
+without an attached browser, `run` launches one when necessary. The requested path must appear
+in `tap specs`, whose list belongs to the session's current testing type.
 
-Other `open` flags worth knowing: `-P/--project <path>` (run Cypress against a project
-other than the cwd), `-C/--config-file`, `-c/--config`, `-e/--env`, `-p/--port`.
-
-Two more things must be true or every test fails for reasons unrelated to `tap`:
-
-- The **app under test must be reachable** — if the project's `baseUrl` is
-  `http://localhost:3000`, that dev server has to be running.
-- The **testing type must be configured** in the Cypress config. Asking for a spec of an
-  unconfigured type fails with a "testing type is not configured" report — but do not count on
-  reaching that report. Measured: `cypress open --component` against a project with no component
-  config leaves a live Cypress process that **never registers as a tappable session**, so
-  `sessions` does not list it. If an e2e session for the same project is running, that one
-  answers instead, and its `passed` verdict looks like your component run succeeded. Check the
-  `TYPE` column before trusting a result.
-
-A browser does not have to be open when you start. `run` launches one if none is. It can run
-only a path listed by `specs`, and that list belongs to the session's current testing type;
-start another `cypress open --component` or `--e2e` session to work in the other type.
-`reporter`, `command`, `pin`, `dom`, `aria` and `inspect` all need a browser attached, so in
-practice the first thing you do after boot is `run`.
-
-## Discovering sessions
+## Find and select a session
 
 ```bash
 npx cypress tap sessions
 npx cypress tap sessions --json
 ```
 
-```
-SESSIONS (2)
-  PID    PROJECT                     TYPE       BROWSER
-  41282  /Users/me/app               e2e        Electron
-  41930  /Users/me/other             component  Firefox (unsupported)
-```
+Human output identifies each session's pid, project, testing type, and browser; unsupported
+browsers carry an `(unsupported)` suffix. JSON additionally provides `browserSupported` and,
+when a runner page exists, `rendererResponsive`. When no sessions exist, `sessions` prints
+guidance rather than a JSON array and exits `0`; use `status --json` for readiness polling.
 
-Fields in `--json`: `pid`, `projectRoot`, `testingType`, `browserAttached`, `browserName`,
-`browserSupported`, and `rendererResponsive` when there was a page to ask.
+Session discovery can be internally partial during startup. For example, JSON may briefly show
+`browserAttached:true` while `browserName` is null and `rendererResponsive` is absent. Treat
+that row as not ready and keep waiting; do not infer browser support or renderer health from
+missing fields.
 
-**`sessions` prints a sentence, not an empty array, when nothing is running** — under
-`--json` as well, **and exits `0`**: `No running Cypress session found. Start Cypress in open
-mode…`. So the command you are most likely to parse is, in exactly the case you are testing
-for, both unparseable and "successful". Detect readiness with `status --json` instead: when it
-can determine a lifecycle stage it returns an object, reports `{"status":"not connected"}`
-when there is nothing to talk to, and carries a `pid` at every other stage. Unsupported browsers
-and unresponsive runners are failures rather than lifecycle stages.
+Without `--session`, commands choose:
 
-`rendererResponsive: false` is the state worth watching for: the Cypress process is alive
-and the browser is attached, but its page will not answer — paused in DevTools, stuck in a
-loop, or starved of memory. Every other command will time out against it. `sessions` is
-deliberately the one command that reports this instead of failing.
+1. the only live supported session;
+2. otherwise, the lowest-pid session whose project root equals the cwd;
+3. otherwise, the lowest pid.
 
-## Which session a command targets
+Unsupported browsers are excluded before selection; unresponsive sessions are not. Therefore:
 
-With no `--session`, `tap` resolves one automatically:
+- run commands from the intended project directory;
+- when multiple sessions exist, bind `--session <pid>` on every call;
+- if calls unexpectedly fail or stall, use `sessions` and select a row that is responsive.
 
-1. Only one live session → that one.
-2. Several → the one whose project root equals the current working directory.
-3. Several, none matching the cwd → the lowest pid.
-
-Sessions running an unsupported browser are dropped before that selection, so a Firefox
-session never shadows a Chromium one.
-
-**Unresponsive sessions are not dropped, and that asymmetry is a trap.** A wedged Cypress still
-wins rule 1 or rule 3, so with no `--session` it can be the session that answers every call —
-each one failing with "the page running it is not responding" while a perfectly healthy Cypress
-sits beside it. Observed on the first attempt to use this skill: a two-hour-old wedged session
-in an unrelated project made auto-selected `status` fail from every cwd until a `-s <pid>` was
-passed. Two consequences worth internalising:
-
-- **A boot loop can never finish** in that state. It swallows the failure as an empty read (by
-  design, see below), keeps waiting, and finally reports "Cypress did not become ready" about a
-  Cypress that booted fine.
-- **`sessions` is the only command that diagnoses it**, because it reports
-  `rendererResponsive: false` instead of failing. When auto-selection misbehaves, list the
-  sessions, pick the pid that is not wedged, and bind `-s <pid>` for the rest of the work.
-
-Rule 3 also means a command issued from project A can silently describe project B — `specs`
-will happily list another project's specs with no attribution, and `run` accepts those paths.
-Only `status` and `sessions` print the project they answered for.
-
-**`status` treats an unknown `--session` as a lifecycle stage, not an error**: a pid that
-never existed, or one that has since exited, reports `not connected` and exits `0`. That is
-deliberate — a poller watching one pid keeps reading `not connected` after that Cypress quits
-instead of suddenly erroring. The cost is that a typo'd pid looks exactly like "still
-booting", so a boot loop can wait forever. Every other command answers a bad pid with "no
-session matched that id" and exit `1`; `tap sessions` is how you get a real one.
-
-An unresponsive runner is different: `status` exits `1` with the "page running it is not
-responding" failure because it reached the session but could not read its lifecycle.
-`sessions` remains available and can show the process with `rendererResponsive: false`.
-
-Two consequences: **`cd` into the project you mean**, and when two sessions share a project
-root (two `cypress open` on the same repo), pass `--session <pid>` explicitly. `tap`'s help
-output prints which pid it targeted and how many candidates matched.
-
-Discovery works off records Cypress writes under its own cache directory, one per process,
-plus an HTTP liveness probe against each. Records whose process is gone are reaped
-automatically, so a crashed Cypress does not leave a session that looks reachable.
+`status --session <unknown-pid>` reports `not connected` and exits `0`. Other commands reject an
+unknown pid. Get valid pids from `sessions`.
 
 ## Lifecycle stages
 
-`status` reports exactly one stage, and **always exits 0** when it can determine one — a
-poller branches on the `status` field and never has to tolerate an error.
+`status` exits `0` whenever it can determine a lifecycle stage:
 
-| Stage | Means | What you can do |
-| --- | --- | --- |
-| `not connected` | No reachable session at all | Start `cypress open`, or wait for boot |
-| `browser not selected` | Session is up, no browser attached | `run` a spec (it launches one) |
-| `spec not selected` | Browser is up, nothing has run | `specs`, then `run` |
-| `loading` | Selected spec is still building; Mocha has not started | Wait; `reporter`, `command`, and `pin` return `SPEC_NOT_STARTED` |
-| `running` | Tests are executing | `reporter` is already readable; app reads are not |
-| `passed` / `failed` | Verdict | Read results; sanity-check the live frame before app reads |
+| Stage                  | Meaning                            | Action                                       |
+| ---------------------- | ---------------------------------- | -------------------------------------------- |
+| `not connected`        | No matching reachable session      | Start Cypress or keep waiting                |
+| `browser not selected` | Session is ready without a browser | `run` a spec; uncommon with `--browser`       |
+| `spec not selected`    | Browser is ready; nothing has run  | `specs`, then `run`                          |
+| `loading`              | The selected spec is building      | Wait                                         |
+| `running`              | Tests are executing                | Reporter data is readable; app reads are not |
+| `passed` / `failed`    | Terminal verdict                   | Read results                                 |
 
-From `loading` onward the payload also carries `spec`, `startedAt` (`null` while loading),
-`totalTests`, `results` (`passed`/`failed`/`pending`/`skipped` counts), `error` when the
-spec failed to build, and `pinned` when a snapshot is pinned.
+Unsupported browsers, unresponsive renderers, and other discovery or compatibility failures
+are not lifecycle stages: `status` exits `1`, and stdout may be empty. Stop polling on a
+nonzero exit; only an exit-`0` payload with transiently missing fields should be retried.
 
-`spec` is worth reading on every poll, not just at the end: it is what distinguishes *your*
-run's verdict from one a superseding `run` or the file watcher produced (see below).
+From `loading` onward, status includes the selected `spec` and `startedAt` (`null` while
+loading). It can also include counts, a build `error`, and the active `pinned` snapshot.
+A build failure is terminal `failed`; read `error` because no tests may exist.
 
-The payload also carries `totalSpecs`. It can become stale when the spec set changes during a
-session — measured at `2` while `specs` correctly reported `5`, though it remains accurate in
-sessions whose spec set does not change. Use `specs` as the authoritative count.
+## Wait for the dispatched run
 
-Human rendering:
+`run` returns after dispatch. Until the incoming run starts, `status` can still show the
+previous run's complete verdict. For every explicit run:
 
-```
-PID    PROJECT        TYPE  BROWSER
-41282  /Users/me/app  e2e   Electron
+1. Capture a structurally valid baseline status.
+2. Dispatch exactly one spec.
+3. Poll one `status --json` response at a time.
+4. Accept only `passed` or `failed` for the requested `spec`, with either:
+   - a non-empty `startedAt` different from the baseline, including for a build that fails on
+     rerun or on a watcher rebuild; or
+   - only for a build failure on first selection, when no run has ever started for that spec
+     and the terminal `startedAt` is null, a non-empty `error` after the baseline changed from a
+     different observable state or that spec was observed in `loading` or `running`.
+5. Bound the polling loop.
 
-✖ cypress/e2e/login.cy.ts  (started at 10:42:19 AM)
-✓ 4  ✖ 1  ○ --
-```
+Within exit-`0` responses, blank, malformed, and partial payloads can occur transiently. Reject
+them rather than treating missing fields as changed values. In particular, retry baseline
+capture before dispatch; a blank baseline would make the previous verdict appear fresh.
 
-## A session that stops accepting runs
+Saving the active spec causes an automatic watcher run. After editing, either use that run or
+wait for it to settle before taking a baseline and dispatching another. Keep only one run in
+flight.
 
-Observed on a live session after a second `run` was fired before the first reached a verdict:
-`run` kept answering `▶ <spec>` with exit `0`, `sessions` reported the session healthy (browser
-attached, renderer responsive), and `status` stayed at `spec not selected` indefinitely —
-across four different specs. Nothing in the output says the request was dropped.
+The canonical fresh-verdict rules are in [SKILL.md](../SKILL.md).
 
-**It has not reproduced since, and deliberate attempts failed to provoke it.** Three runs fired
-into a 60-second spec mid-flight were each accepted and superseded cleanly, the last dispatch
-winning; the session stayed responsive and ran normally afterwards. Deleting the currently
-selected spec — the other suspected cause — dropped the results and returned the session to
-`spec not selected`, but the very next `run` worked. So treat the wedge as a rare state to
-detect and recover from, not as the expected outcome of overlapping runs.
+## Timeouts and polling cost
 
-What overlapping runs *do* reliably cause is a misread result: the superseding run's verdict
-arrives with a fresh `startedAt` under a **different `spec`**, and a poller comparing only
-`startedAt` reports it as the answer to the run it dispatched.
+For connection-backed commands, `--timeout <ms>` replaces both the runner-discovery timeout
+and the limit for each bounded CDP call in that invocation; it does not bound the whole spec.
+The `runSpec` dispatch has its own 60-second GraphQL timeout. Use a bounded outer loop for the
+run itself. A two-second sleep between status calls is a sensible floor because each invocation
+starts Node and probes the session.
 
-Detect the wedge by treating "no verdict with a fresh `startedAt`" as a failed run rather than
-as slowness (the bounded loop in SKILL.md does this), and recover by restarting `cypress open`.
-Avoid both problems by never having two runs in flight, comparing `spec` as well as `startedAt`,
-and not deleting or renaming the spec that is currently selected.
+Do not raise `--timeout` in the run-polling workflow. If bounded `status` polling fails, inspect
+`rendererResponsive` with `sessions`; restart a wedged renderer. Raise `--timeout` only for a
+specific read against a known-responsive, unusually heavy page.
 
-## Why `startedAt` matters
-
-A rerun leaves the previous run's verdict readable until the new run actually starts —
-identical spec, identical counts. `startedAt` is the only field that changes. So the
-correct pattern is always: read `startedAt`, `run`, then wait for a verdict whose
-`startedAt` differs. Skipping that check is the single most common way an agent reports the
-*previous* run's result as if it were the new one.
-
-Two things weaken `startedAt` as a signal, and both have bitten real sessions:
-
-- **A fresh `startedAt` does not mean *your* run.** Open mode reruns the active spec whenever
-  its file is saved — measured at 3–6s from write to a new `startedAt`, with no `tap run`
-  issued, and a short spec can have *finished* inside that window. In an authoring loop the
-  watcher's run and yours race, and the poll happily reports the watcher's. When you have just
-  written the spec, drain that run first and take the baseline afterwards.
-- **A blank read is not a change.** A transient failure can yield empty fields several times a
-  session. The `tap_state` helper rejects blank or malformed reads, and the baseline loop retries
-  until one succeeds. Verdict comparisons must still require a non-empty `startedAt`; treating
-  `""` as a changed run identity can end the poll on a phantom verdict.
-- **Reads can be partial, not just blank.** Measured: `{"status":"spec not selected"}` with no
-  `pid`, `projectRoot` or anything else, sandwiched between five complete reads seconds either
-  side. One field arriving is no guarantee its siblings did, so check each field you branch on
-  rather than inferring the payload is whole from `status` alone.
-
-## Timeouts
-
-`--timeout <ms>` (default `30000`) bounds **one call into Cypress**, not a whole run. Raise
-it when the page is heavy or the machine is loaded; it will not make a slow spec finish
-sooner. Session discovery uses its own short probe so that an unresponsive session is
-skipped rather than blocking the scan.
-
-## Cost per call
-
-Each invocation pays Node startup: roughly 0.7s for `specs`/`reporter`/`dom`, up to ~1.5s for
-`status` (it probes the session).
-
-**Those figures hold only for a healthy session.** Against an unresponsive one, `status` took
-**9s** with no `--timeout` (the failure text names a 2000ms probe) and **43s** with
-`--timeout 20000` — roughly double the timeout you ask for, not a fraction of a second. A
-40-iteration boot loop budgeted at two minutes takes eight. If a loop is running far behind the
-wall clock you predicted, stop and check `sessions`: that skew is the symptom.
-
-Consequences for a polling loop: a 2s sleep is the sensible floor, parse all needed fields from
-one `status --json` response, and remember that a short spec can start *and finish* between two
-consecutive calls. Reading one wide result beats several narrow ones — prefer
-`reporter --test-id` over a `command` call per row. Once a fresh verdict exists, independent
-reads may be issued concurrently.
-
-## Telemetry
-
-Each `tap` invocation reports the command name, the flag *names* it parsed, detected agent,
-exit code, error code, duration, and the machine/session/user identifiers available to the
-CLI. It never reports selectors, spec paths, test titles, project paths, or other flag values.
-Set `CYPRESS_DISABLE_GUEST_TELEMETRY` to any value to turn off everything Cypress reports
-without an account behind it.
+For specific failure messages and recovery steps, read
+[troubleshooting.md](troubleshooting.md).

--- a/skills/cypress-tap/references/session-lifecycle.md
+++ b/skills/cypress-tap/references/session-lifecycle.md
@@ -1,0 +1,240 @@
+# Sessions and the run lifecycle
+
+## Starting a session `tap` can drive
+
+`tap` never launches Cypress. Something must run `cypress open` first, in the background:
+
+```bash
+cd /path/to/project
+npx cypress open --e2e --browser electron &          # e2e
+npx cypress open --component --browser electron &    # component testing
+```
+
+Those `npx` examples assume an installed Cypress binary. When smoke-testing `tap` from the
+Cypress source monorepo, an unbuilt checkout can report `Cypress binary version: not installed`;
+run the root development launcher instead:
+
+```bash
+yarn dev --project /path/to/project
+```
+
+The root script wraps the development-mode gulp workflow that builds and launches Cypress;
+`npx cypress open` expects an installed binary.
+
+Electron is the safest default — it ships with Cypress, so nothing external has to be
+installed or discoverable. Chrome, Chromium and Edge work equally well. Firefox and WebKit
+do not: `tap` drives the browser over the Chrome DevTools Protocol, so a Firefox or WebKit
+session is reported as `unsupported` and every command except `sessions` refuses it.
+
+Other `open` flags worth knowing: `-P/--project <path>` (run Cypress against a project
+other than the cwd), `-C/--config-file`, `-c/--config`, `-e/--env`, `-p/--port`.
+
+Two more things must be true or every test fails for reasons unrelated to `tap`:
+
+- The **app under test must be reachable** — if the project's `baseUrl` is
+  `http://localhost:3000`, that dev server has to be running.
+- The **testing type must be configured** in the Cypress config. Asking for a spec of an
+  unconfigured type fails with a "testing type is not configured" report — but do not count on
+  reaching that report. Measured: `cypress open --component` against a project with no component
+  config leaves a live Cypress process that **never registers as a tappable session**, so
+  `sessions` does not list it. If an e2e session for the same project is running, that one
+  answers instead, and its `passed` verdict looks like your component run succeeded. Check the
+  `TYPE` column before trusting a result.
+
+A browser does not have to be open when you start. `run` launches one if none is. It can run
+only a path listed by `specs`, and that list belongs to the session's current testing type;
+start another `cypress open --component` or `--e2e` session to work in the other type.
+`reporter`, `command`, `pin`, `dom`, `aria` and `inspect` all need a browser attached, so in
+practice the first thing you do after boot is `run`.
+
+## Discovering sessions
+
+```bash
+npx cypress tap sessions
+npx cypress tap sessions --json
+```
+
+```
+SESSIONS (2)
+  PID    PROJECT                     TYPE       BROWSER
+  41282  /Users/me/app               e2e        Electron
+  41930  /Users/me/other             component  Firefox (unsupported)
+```
+
+Fields in `--json`: `pid`, `projectRoot`, `testingType`, `browserAttached`, `browserName`,
+`browserSupported`, and `rendererResponsive` when there was a page to ask.
+
+**`sessions` prints a sentence, not an empty array, when nothing is running** — under
+`--json` as well, **and exits `0`**: `No running Cypress session found. Start Cypress in open
+mode…`. So the command you are most likely to parse is, in exactly the case you are testing
+for, both unparseable and "successful". Detect readiness with `status --json` instead: when it
+can determine a lifecycle stage it returns an object, reports `{"status":"not connected"}`
+when there is nothing to talk to, and carries a `pid` at every other stage. Unsupported browsers
+and unresponsive runners are failures rather than lifecycle stages.
+
+`rendererResponsive: false` is the state worth watching for: the Cypress process is alive
+and the browser is attached, but its page will not answer — paused in DevTools, stuck in a
+loop, or starved of memory. Every other command will time out against it. `sessions` is
+deliberately the one command that reports this instead of failing.
+
+## Which session a command targets
+
+With no `--session`, `tap` resolves one automatically:
+
+1. Only one live session → that one.
+2. Several → the one whose project root equals the current working directory.
+3. Several, none matching the cwd → the lowest pid.
+
+Sessions running an unsupported browser are dropped before that selection, so a Firefox
+session never shadows a Chromium one.
+
+**Unresponsive sessions are not dropped, and that asymmetry is a trap.** A wedged Cypress still
+wins rule 1 or rule 3, so with no `--session` it can be the session that answers every call —
+each one failing with "the page running it is not responding" while a perfectly healthy Cypress
+sits beside it. Observed on the first attempt to use this skill: a two-hour-old wedged session
+in an unrelated project made auto-selected `status` fail from every cwd until a `-s <pid>` was
+passed. Two consequences worth internalising:
+
+- **A boot loop can never finish** in that state. It swallows the failure as an empty read (by
+  design, see below), keeps waiting, and finally reports "Cypress did not become ready" about a
+  Cypress that booted fine.
+- **`sessions` is the only command that diagnoses it**, because it reports
+  `rendererResponsive: false` instead of failing. When auto-selection misbehaves, list the
+  sessions, pick the pid that is not wedged, and bind `-s <pid>` for the rest of the work.
+
+Rule 3 also means a command issued from project A can silently describe project B — `specs`
+will happily list another project's specs with no attribution, and `run` accepts those paths.
+Only `status` and `sessions` print the project they answered for.
+
+**`status` treats an unknown `--session` as a lifecycle stage, not an error**: a pid that
+never existed, or one that has since exited, reports `not connected` and exits `0`. That is
+deliberate — a poller watching one pid keeps reading `not connected` after that Cypress quits
+instead of suddenly erroring. The cost is that a typo'd pid looks exactly like "still
+booting", so a boot loop can wait forever. Every other command answers a bad pid with "no
+session matched that id" and exit `1`; `tap sessions` is how you get a real one.
+
+An unresponsive runner is different: `status` exits `1` with the "page running it is not
+responding" failure because it reached the session but could not read its lifecycle.
+`sessions` remains available and can show the process with `rendererResponsive: false`.
+
+Two consequences: **`cd` into the project you mean**, and when two sessions share a project
+root (two `cypress open` on the same repo), pass `--session <pid>` explicitly. `tap`'s help
+output prints which pid it targeted and how many candidates matched.
+
+Discovery works off records Cypress writes under its own cache directory, one per process,
+plus an HTTP liveness probe against each. Records whose process is gone are reaped
+automatically, so a crashed Cypress does not leave a session that looks reachable.
+
+## Lifecycle stages
+
+`status` reports exactly one stage, and **always exits 0** when it can determine one — a
+poller branches on the `status` field and never has to tolerate an error.
+
+| Stage | Means | What you can do |
+| --- | --- | --- |
+| `not connected` | No reachable session at all | Start `cypress open`, or wait for boot |
+| `browser not selected` | Session is up, no browser attached | `run` a spec (it launches one) |
+| `spec not selected` | Browser is up, nothing has run | `specs`, then `run` |
+| `loading` | Selected spec is still building; Mocha has not started | Wait; `reporter`, `command`, and `pin` return `SPEC_NOT_STARTED` |
+| `running` | Tests are executing | `reporter` is already readable; app reads are not |
+| `passed` / `failed` | Verdict | Read results; sanity-check the live frame before app reads |
+
+From `loading` onward the payload also carries `spec`, `startedAt` (`null` while loading),
+`totalTests`, `results` (`passed`/`failed`/`pending`/`skipped` counts), `error` when the
+spec failed to build, and `pinned` when a snapshot is pinned.
+
+`spec` is worth reading on every poll, not just at the end: it is what distinguishes *your*
+run's verdict from one a superseding `run` or the file watcher produced (see below).
+
+The payload also carries `totalSpecs`. It can become stale when the spec set changes during a
+session — measured at `2` while `specs` correctly reported `5`, though it remains accurate in
+sessions whose spec set does not change. Use `specs` as the authoritative count.
+
+Human rendering:
+
+```
+PID    PROJECT        TYPE  BROWSER
+41282  /Users/me/app  e2e   Electron
+
+✖ cypress/e2e/login.cy.ts  (started at 10:42:19 AM)
+✓ 4  ✖ 1  ○ --
+```
+
+## A session that stops accepting runs
+
+Observed on a live session after a second `run` was fired before the first reached a verdict:
+`run` kept answering `▶ <spec>` with exit `0`, `sessions` reported the session healthy (browser
+attached, renderer responsive), and `status` stayed at `spec not selected` indefinitely —
+across four different specs. Nothing in the output says the request was dropped.
+
+**It has not reproduced since, and deliberate attempts failed to provoke it.** Three runs fired
+into a 60-second spec mid-flight were each accepted and superseded cleanly, the last dispatch
+winning; the session stayed responsive and ran normally afterwards. Deleting the currently
+selected spec — the other suspected cause — dropped the results and returned the session to
+`spec not selected`, but the very next `run` worked. So treat the wedge as a rare state to
+detect and recover from, not as the expected outcome of overlapping runs.
+
+What overlapping runs *do* reliably cause is a misread result: the superseding run's verdict
+arrives with a fresh `startedAt` under a **different `spec`**, and a poller comparing only
+`startedAt` reports it as the answer to the run it dispatched.
+
+Detect the wedge by treating "no verdict with a fresh `startedAt`" as a failed run rather than
+as slowness (the bounded loop in SKILL.md does this), and recover by restarting `cypress open`.
+Avoid both problems by never having two runs in flight, comparing `spec` as well as `startedAt`,
+and not deleting or renaming the spec that is currently selected.
+
+## Why `startedAt` matters
+
+A rerun leaves the previous run's verdict readable until the new run actually starts —
+identical spec, identical counts. `startedAt` is the only field that changes. So the
+correct pattern is always: read `startedAt`, `run`, then wait for a verdict whose
+`startedAt` differs. Skipping that check is the single most common way an agent reports the
+*previous* run's result as if it were the new one.
+
+Two things weaken `startedAt` as a signal, and both have bitten real sessions:
+
+- **A fresh `startedAt` does not mean *your* run.** Open mode reruns the active spec whenever
+  its file is saved — measured at 3–6s from write to a new `startedAt`, with no `tap run`
+  issued, and a short spec can have *finished* inside that window. In an authoring loop the
+  watcher's run and yours race, and the poll happily reports the watcher's. When you have just
+  written the spec, drain that run first and take the baseline afterwards.
+- **A blank read is not a change.** A transient failure yields empty fields rather than an
+  error, several times a session in practice. The `tap_state` helper returns empty on purpose
+  so the loop waits; your comparison must require a non-empty value before it decides anything.
+  Treating `""` as "different from the baseline" ends the poll instantly on a phantom verdict.
+- **Reads can be partial, not just blank.** Measured: `{"status":"spec not selected"}` with no
+  `pid`, `projectRoot` or anything else, sandwiched between five complete reads seconds either
+  side. One field arriving is no guarantee its siblings did, so check each field you branch on
+  rather than inferring the payload is whole from `status` alone.
+
+## Timeouts
+
+`--timeout <ms>` (default `30000`) bounds **one call into Cypress**, not a whole run. Raise
+it when the page is heavy or the machine is loaded; it will not make a slow spec finish
+sooner. Session discovery uses its own short probe so that an unresponsive session is
+skipped rather than blocking the scan.
+
+## Cost per call
+
+Each invocation pays Node startup: roughly 0.7s for `specs`/`reporter`/`dom`, up to ~1.5s for
+`status` (it probes the session).
+
+**Those figures hold only for a healthy session.** Against an unresponsive one, `status` took
+**9s** with no `--timeout` (the failure text names a 2000ms probe) and **43s** with
+`--timeout 20000` — roughly double the timeout you ask for, not a fraction of a second. A
+40-iteration boot loop budgeted at two minutes takes eight. If a loop is running far behind the
+wall clock you predicted, stop and check `sessions`: that skew is the symptom.
+
+Consequences for a polling loop: a 2s sleep is the sensible floor, parse all needed fields from
+one `status --json` response, and remember that a short spec can start *and finish* between two
+consecutive calls. Reading one wide result beats several narrow ones — prefer
+`reporter --test-id` over a `command` call per row. Once a fresh verdict exists, independent
+reads may be issued concurrently.
+
+## Telemetry
+
+Each `tap` invocation reports the command name, the flag *names* it parsed, detected agent,
+exit code, error code, duration, and the machine/session/user identifiers available to the
+CLI. It never reports selectors, spec paths, test titles, project paths, or other flag values.
+Set `CYPRESS_DISABLE_GUEST_TELEMETRY` to any value to turn off everything Cypress reports
+without an account behind it.

--- a/skills/cypress-tap/references/session-lifecycle.md
+++ b/skills/cypress-tap/references/session-lifecycle.md
@@ -198,10 +198,10 @@ Two things weaken `startedAt` as a signal, and both have bitten real sessions:
   issued, and a short spec can have *finished* inside that window. In an authoring loop the
   watcher's run and yours race, and the poll happily reports the watcher's. When you have just
   written the spec, drain that run first and take the baseline afterwards.
-- **A blank read is not a change.** A transient failure yields empty fields rather than an
-  error, several times a session in practice. The `tap_state` helper returns empty on purpose
-  so the loop waits; your comparison must require a non-empty value before it decides anything.
-  Treating `""` as "different from the baseline" ends the poll instantly on a phantom verdict.
+- **A blank read is not a change.** A transient failure can yield empty fields several times a
+  session. The `tap_state` helper rejects blank or malformed reads, and the baseline loop retries
+  until one succeeds. Verdict comparisons must still require a non-empty `startedAt`; treating
+  `""` as a changed run identity can end the poll on a phantom verdict.
 - **Reads can be partial, not just blank.** Measured: `{"status":"spec not selected"}` with no
   `pid`, `projectRoot` or anything else, sandwiched between five complete reads seconds either
   side. One field arriving is no guarantee its siblings did, so check each field you branch on

--- a/skills/cypress-tap/references/troubleshooting.md
+++ b/skills/cypress-tap/references/troubleshooting.md
@@ -1,183 +1,96 @@
 # Troubleshooting
 
-`tap` reports failures as prose on stderr and exits `1`. The output states the condition, the
-specifics, then what to do — there are no error codes to match on, so **branch on the exit
-code** and read the text.
+On supported builds, `tap` failures are generally prose on stderr with exit `1`; branch on exit
+status before parsing output. Selector ambiguity intentionally lists matches on stdout, and
+older compatibility failures may also use stdout.
 
-## Cannot find or reach a session
+## Session problems
 
-| Reported | Why | Do |
-| --- | --- | --- |
-| Could not find a Cypress session to tap into. | No session record at all | Start `cypress open`; if you just did, it is still booting — poll `status` |
-| No Cypress session matched the provided session id. | `--session <pid>` named nothing | `tap sessions` for the live pids. **`status` is the exception** — it reports `not connected` and exits `0` for an unknown pid, so a poller never learns the pid was wrong |
-| Could not reach the Cypress session. | Records exist but nothing answers, or the connection dropped mid-command | Confirm Cypress is still open with a browser; rerun |
-| The Cypress session is running, but no test browser is open. | Session up, no browser attached | `tap run <spec>` (it launches one), or launch one in the app |
-| The Cypress session is running an unsupported browser. | Firefox or WebKit | Reopen with `--browser electron` / `chrome` / `edge` |
-| The Cypress session is reachable, but the page running it is not responding. | Renderer wedged: paused in DevTools, infinite loop, out of memory. **Or you did not mean this session at all** — auto-selection does not skip wedged sessions | `tap sessions`, then `-s <pid>` for one that is responsive; restart the wedged Cypress. Raising `--timeout` only helps a *slow* page — see below |
+| Symptom                 | Action                                                           |
+| ----------------------- | ---------------------------------------------------------------- |
+| No session found        | Start `cypress open`, select a testing type, then retry          |
+| Unknown `--session` pid | Run `tap sessions` and use a listed pid                          |
+| Session unreachable     | Confirm Cypress and its browser are still open                   |
+| No browser attached     | Run a listed spec; `run` can launch the browser                  |
+| Unsupported browser     | Reopen in Electron, Chrome, Chromium, or Edge                    |
+| Renderer not responding | Check `tap sessions`; select a responsive pid or restart Cypress |
 
-`tap sessions` is the diagnostic of last resort: it never fails, and it reports browser
-attachment and renderer health per session instead of erroring.
+`status` reports `not connected` with exit `0` for no session, a stale session, or an unknown
+pid. It exits `1` for errors such as an explicitly selected unsupported-browser session. Treat
+that as a failure, not a transient empty status. `sessions --json` distinguishes live pids and
+reports renderer health.
 
-`status` deliberately collapses no session, an unknown pid, and a stale session record into
-`not connected` with exit `0`. An unresponsive runner instead makes `status` exit `1` with the
-"page running it is not responding" failure; `sessions` can confirm
-`rendererResponsive: false`.
+Without `--session`, an unresponsive process can still win automatic selection. If healthy and
+wedged sessions coexist, bind `--session <pid>` to a responsive row. Do not raise `--timeout`
+for polling; it does not repair a wedged renderer.
 
-**A wedged session you have never heard of can break every command.** With no `--session`,
-selection prefers the cwd's project and otherwise takes the lowest pid — and unlike an
-unsupported browser, an unresponsive session is *not* filtered out first. So a stale Cypress
-left running in an unrelated project can answer, and every call fails against it while a healthy
-session sits beside it. This is the first thing to rule out when `tap` "stops working" for no
-reason: `tap sessions`, then bind `-s <pid>` to the pid that is responsive.
+## Version and binary mismatch
 
-**Raising `--timeout` does not un-wedge a renderer; it just costs more.** Measured against a
-genuinely wedged session: the default `status` failed after **9s** (its message names a 2000ms
-probe), and `--timeout 20000` failed after **43s** — about twice the value you pass. Raise
-`--timeout` for a *heavy but live* page; restart Cypress for a wedged one.
+Schema mismatch errors name which side is older; update that Cypress installation and restart
+the session when needed.
 
-## Version mismatch
-
-| Reported | Do |
-| --- | --- |
-| The targeted Cypress session is newer than this CLI. | Update the CLI: `npm install --save-dev cypress@latest` |
-| The targeted Cypress session is older than this CLI. | Update Cypress in the running project, restart it |
-
-Both name the two versions involved. They happen when a globally-installed `cypress` binary
-taps a project pinned to a different version. Running `npx cypress tap` from inside the project
-is the simplest way to keep both halves compatible — but it is not a requirement, and it fails
-outright when the project's Cypress predates `tap`:
-
-| Reported | Why | Do |
-| --- | --- | --- |
-| `Unknown command "tap"` plus the `cypress` usage text | Not a tap failure — `npx` resolved a Cypress older than 15.21, usually the target project's pinned copy | Run `tap` from a checkout whose Cypress has it and pass `-s <pid>`. `tap` is a client and needs only to be version-compatible with the session, not installed in the project it inspects |
-
-That message is easy to misread inside a script: the wrapper reports the step as failed, so a
-loop looks like it could not start a run when the real problem is which binary answered.
-
-**It is worse than that, and this is the single most common way to lose time with `tap`.**
-Commander prints the usage text to **stdout**, so the idiomatic dispatch check
+If `npx cypress tap` prints `Unknown command "tap"`, cwd resolved a Cypress version without
+`tap`. Resolve commands from a compatible checkout and pass the target pid:
 
 ```bash
-npx cypress tap run "$SPEC" >/dev/null || { echo "dispatch failed"; exit 2; }
+npx --prefix "PATH_TO_TAP_CHECKOUT" cypress tap --session 73952 reporter
 ```
 
-throws away the only evidence and leaves a bare `dispatch failed` with no cause. Because cwd
-selects the binary on *every* call, this reappears the moment any `cd` runs earlier in a
-compound command or inside the script — the first ten invocations work and the eleventh does
-not. Two habits remove it for good:
-
-- Pin the binary in a bash/zsh function that forwards `"$@"`, or `cd` to that checkout as the
-  first line of the script, instead of relying on ambient cwd:
-
-  ```bash
-  tap_cli () {
-    npx --prefix "/tap-capable/checkout" cypress tap -s 73952 "$@"
-  }
-  ```
-- When a dispatch fails, print stdout before deciding what went wrong. `Unknown command "tap"`
-  and a real dispatch failure are indistinguishable once stdout is gone.
-
-Confirm which binary is answering at any time with `npx cypress tap --help`: it needs no
-session, and it fails the same way when cwd is wrong.
+Do not discard dispatch stdout: older Commander versions may print unknown-command evidence
+there. Confirm the resolved Cypress version from package metadata or the lockfile before using
+`tap --help`; older prereleases may attempt session discovery and print an error on stdout
+instead of help.
 
 ## Spec and run problems
 
-| Reported | Why | Do |
-| --- | --- | --- |
-| No spec has run yet. | Read a result before running anything | `tap run <spec>`, wait for a verdict |
-| The spec has not started yet. | Spec is still `loading`; Mocha has not started | Keep polling; the run-level loop owns the timeout |
-| The spec … is currently running. | App read attempted mid-run | Poll `status` until `passed`/`failed` |
-| The Cypress session has no spec matching that path. | Path is not in the specs list | `tap specs` for the exact path; if the file exists but is unlisted, widen `specPattern` |
-| The Cypress session could not start the spec. | The `runSpec` request failed | `tap status`, then retry |
-| That testing type is not configured for this project. | Spec belongs to a type the config does not define | Configure it, or open Cypress in a type the project supports. Note the session may never appear at all — see below |
-| The Cypress session has no project open. | Session sitting with no project | Open a project in Cypress |
+| Symptom                                        | Action                                                                                                      |
+| ---------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| No spec has run                                | `tap specs`, dispatch one, then wait for a fresh verdict                                                    |
+| Spec is loading or running                     | Continue the bounded status poll                                                                            |
+| No matching spec path                          | Copy the exact path from `tap specs`; check `specPattern`                                                   |
+| Testing type is not configured                 | Configure it or open Cypress in a supported project type                                                    |
+| Session has no project                         | Open the project in Cypress                                                                                 |
+| Build failure                                  | Read `status.error`; reporter data may be empty                                                             |
+| Dispatch succeeds but no fresh verdict arrives | Confirm the expected `spec`, session pid, and watcher activity; restart Cypress if the bounded loop expires |
 
-**A session for an unconfigured testing type never registers** — `cypress open --component`
-against a project with no `component` block leaves a live Cypress process that `tap sessions`
-does not list, so there is nothing to target and no "not configured" report to read. Worse, if
-an e2e session for that same project is running, auto-selection answers with *that* one, whose
-`passed` verdict reads like your component run succeeded. Check the `TYPE` column on `status`
-before believing a result, and configure the testing type before expecting to tap it.
+Open mode automatically reruns the active spec when it is saved. After editing, let that run
+settle before taking a baseline and explicitly dispatching, or use the watcher run itself.
 
-**`run` succeeds but nothing runs** — `status` stays at `spec not selected` while `run` keeps
-answering `▶ <spec>` with exit `0`. The session has stopped accepting run requests; seen once
-after two runs were put in flight at once. `sessions` still shows it healthy. Restart
-`cypress open`; the CLI cannot un-wedge it.
+Results and snapshots live in the runner's memory. A rerun, restart, interrupted run, or
+renaming/deleting the selected spec can remove them; inspect results before editing again.
 
-This state is **rare and has not reproduced**: firing three runs into a spec mid-flight, and
-deleting the spec that was currently selected, were both re-tested deliberately and neither
-wedged the session — runs superseded cleanly and the next `run` worked. Keep one run in flight
-as discipline, but when a run seems lost, first rule out the two likelier explanations: a
-verdict that belongs to a *superseding* run (compare `spec`, not just `startedAt`), and a
-wedged or wrong session answering your calls (see above).
+## Test, command, and snapshot ids
 
-A spec that **fails to build** is not an error — `status` reports `failed` with the reason in
-`error` and no test counts. Read `error`; it holds the bundler/compile failure. `reporter` is
-empty, and app reads may still succeed against an empty frame, so neither is the diagnostic.
+| Symptom                 | Action                                                                |
+| ----------------------- | --------------------------------------------------------------------- |
+| Test id not found       | Run `tap reporter`                                                    |
+| Attempt not found       | Use a 1-based attempt shown by reporter, or omit it for latest        |
+| Command id not found    | Run `tap reporter --test-id <id>`                                     |
+| Command id is ambiguous | Qualify it, for example `h1:3`                                        |
+| Snapshot not found      | Use a listed name or 1-based snapshot index                           |
+| No snapshot available   | Rerun the spec or choose a row whose `command` output lists snapshots |
 
-**A run you did not start** — `status` moves to `loading`/`running` on its own, or `startedAt`
-changes before your `run` lands. Open mode watches spec files and reruns the active spec when
-one is saved; measured here, `startedAt` moved within 3–6s of a write, sometimes with the
-rerun already finished. This is not a fault, but
-it breaks the verdict rule if the baseline `startedAt` was captured before the edit, and pairs
-with your own dispatch to put two runs in flight. After writing a spec, let the watcher's run
-reach a verdict, take the baseline from *there*, and only then dispatch — or let the watcher's
-run be the one you read.
+## App-read problems
 
-**Results disappear between commands** — `reporter` answers "No spec has run yet" and `status`
-drops to `spec not selected`, on a session that was fine a moment ago. Results live only in the
-app's memory, so an interrupted run, a restart, or deleting/renaming the spec that ran clears
-them. Nothing is broken: rerun the spec. The lesson is ordering — read everything you need out
-of a run *before* editing the spec, because the edit both drops the old results and starts a
-new run.
+- A selector miss is successful: `dom` and `inspect` return `found:false`; `aria` returns an
+  empty tree.
+- Selector ambiguity exits `1` with candidates on stdout. Use a unique selector or
+  `--at <0-based-index>`.
+- For a live form-control value, use `aria`; `dom` and `inspect` can show the initial HTML
+  `value` attribute instead. For live-region or toast text, use `dom`; `aria` may omit its text.
+- If everything appears absent after a verdict, verify that the live frame contains the app.
+  Pin a retained command snapshot when the final frame is blank.
+- `pin --clear` with no active pin exits `0` with `cleared:false`. Its human
+  `FAILED TO CLEAR PIN` wording describes a benign no-op; do not retry it as a failure.
+- On a confirmed supported build, invalid options and missing companion flags print generated
+  command help; use `npx cypress tap <command> --help` for current flags.
 
-## Ids that matched nothing
+## Unclassified failures
 
-| Reported | Do |
-| --- | --- |
-| No test in this spec matched that id. | `tap reporter` (no `--test-id`) lists the ids |
-| No attempt of this test matched that number. | `--attempt` is 1-based; the message names how many exist |
-| No command in this test matched that id. | `tap reporter --test-id <id>` lists the rows |
-| That command id matches more than one row of the test. | Qualify it as `<hookId>:<number>`, e.g. `h1:3` |
-| No snapshot of this command matched that name or index. | The message lists the available snapshots; `--at` takes a name or 1-based index |
-| That command has no DOM snapshot to pin. | Rerun the spec (snapshots are evicted per `numTestsKeptInMemory`), or pick a row whose `command` output lists snapshots |
-
-## App-under-test reads
-
-A selector matching nothing is not a CLI failure. `dom` and `inspect` report `found:false`
-with exit `0`; treat that as an absent element, not a broken session. `aria` returns an empty
-tree for either a miss or a matched element with no accessibility node, so confirm absence
-with `dom` or `inspect`.
-
-**Every expected element appears absent after a verdict** — first verify that the live frame is
-actually the app. A trailing pending/skipped test can leave the runner on a blank placeholder
-while `aria`, `dom`, and `inspect` continue to exit `0` with plausible empty/not-found results.
-Sanity-check a known app anchor. If the run ended on a pending test and the frame is blank, pin
-a snapshot from the last real command, inspect it, then `pin --clear`.
-
-| Reported | Why | Do |
-| --- | --- | --- |
-| Failed to determine the app under test in the Cypress session. | No app frame in the runner page | Rerun the spec; or `pin` a command to read an earlier snapshot |
-| ⚠ selector … matched N elements but must be unique | Ambiguous selector (exit `1`, matches listed on stdout) | Re-run with `--at <0-based index>` or a unique selector from the list |
-| Expected `--at` to be a whole number, 0 or greater. | Bad flag value | Fix the value; these are checked before a session is even resolved |
-
-## Invocation problems
-
-Unknown command, unknown flag, missing argument, missing required option — each prints what
-you gave, then the generated help for the command you called. `--help` works with no session
-running, so `npx cypress tap <command> --help` is always available as the source of truth.
-
-`MISSING_COMPANION_OPTION`-style failures name both flags: e.g. `--attempt` without
-`--test-id` (pass the test id, or drop `--attempt` for the spec-wide view).
-
-## When nothing above fits
-
-"An error occurred." / "The Cypress session failed while running the command." mean the
-failure carried no actionable condition. Get the diagnostic:
+Retry once after checking `status`. If the failure remains generic, collect diagnostics:
 
 ```bash
 DEBUG=cypress:cli:tap,cypress:cli:cypress-sessions npx cypress tap <command> …
 ```
 
-That prints the underlying stack, the resolved session, and the calls made — the detail to
-attach to a GitHub issue.
+Include that output and the invocation in a Cypress issue.

--- a/skills/cypress-tap/references/troubleshooting.md
+++ b/skills/cypress-tap/references/troubleshooting.md
@@ -1,0 +1,183 @@
+# Troubleshooting
+
+`tap` reports failures as prose on stderr and exits `1`. The output states the condition, the
+specifics, then what to do — there are no error codes to match on, so **branch on the exit
+code** and read the text.
+
+## Cannot find or reach a session
+
+| Reported | Why | Do |
+| --- | --- | --- |
+| Could not find a Cypress session to tap into. | No session record at all | Start `cypress open`; if you just did, it is still booting — poll `status` |
+| No Cypress session matched the provided session id. | `--session <pid>` named nothing | `tap sessions` for the live pids. **`status` is the exception** — it reports `not connected` and exits `0` for an unknown pid, so a poller never learns the pid was wrong |
+| Could not reach the Cypress session. | Records exist but nothing answers, or the connection dropped mid-command | Confirm Cypress is still open with a browser; rerun |
+| The Cypress session is running, but no test browser is open. | Session up, no browser attached | `tap run <spec>` (it launches one), or launch one in the app |
+| The Cypress session is running an unsupported browser. | Firefox or WebKit | Reopen with `--browser electron` / `chrome` / `edge` |
+| The Cypress session is reachable, but the page running it is not responding. | Renderer wedged: paused in DevTools, infinite loop, out of memory. **Or you did not mean this session at all** — auto-selection does not skip wedged sessions | `tap sessions`, then `-s <pid>` for one that is responsive; restart the wedged Cypress. Raising `--timeout` only helps a *slow* page — see below |
+
+`tap sessions` is the diagnostic of last resort: it never fails, and it reports browser
+attachment and renderer health per session instead of erroring.
+
+`status` deliberately collapses no session, an unknown pid, and a stale session record into
+`not connected` with exit `0`. An unresponsive runner instead makes `status` exit `1` with the
+"page running it is not responding" failure; `sessions` can confirm
+`rendererResponsive: false`.
+
+**A wedged session you have never heard of can break every command.** With no `--session`,
+selection prefers the cwd's project and otherwise takes the lowest pid — and unlike an
+unsupported browser, an unresponsive session is *not* filtered out first. So a stale Cypress
+left running in an unrelated project can answer, and every call fails against it while a healthy
+session sits beside it. This is the first thing to rule out when `tap` "stops working" for no
+reason: `tap sessions`, then bind `-s <pid>` to the pid that is responsive.
+
+**Raising `--timeout` does not un-wedge a renderer; it just costs more.** Measured against a
+genuinely wedged session: the default `status` failed after **9s** (its message names a 2000ms
+probe), and `--timeout 20000` failed after **43s** — about twice the value you pass. Raise
+`--timeout` for a *heavy but live* page; restart Cypress for a wedged one.
+
+## Version mismatch
+
+| Reported | Do |
+| --- | --- |
+| The targeted Cypress session is newer than this CLI. | Update the CLI: `npm install --save-dev cypress@latest` |
+| The targeted Cypress session is older than this CLI. | Update Cypress in the running project, restart it |
+
+Both name the two versions involved. They happen when a globally-installed `cypress` binary
+taps a project pinned to a different version. Running `npx cypress tap` from inside the project
+is the simplest way to keep both halves compatible — but it is not a requirement, and it fails
+outright when the project's Cypress predates `tap`:
+
+| Reported | Why | Do |
+| --- | --- | --- |
+| `Unknown command "tap"` plus the `cypress` usage text | Not a tap failure — `npx` resolved a Cypress older than 15.21, usually the target project's pinned copy | Run `tap` from a checkout whose Cypress has it and pass `-s <pid>`. `tap` is a client and needs only to be version-compatible with the session, not installed in the project it inspects |
+
+That message is easy to misread inside a script: the wrapper reports the step as failed, so a
+loop looks like it could not start a run when the real problem is which binary answered.
+
+**It is worse than that, and this is the single most common way to lose time with `tap`.**
+Commander prints the usage text to **stdout**, so the idiomatic dispatch check
+
+```bash
+npx cypress tap run "$SPEC" >/dev/null || { echo "dispatch failed"; exit 2; }
+```
+
+throws away the only evidence and leaves a bare `dispatch failed` with no cause. Because cwd
+selects the binary on *every* call, this reappears the moment any `cd` runs earlier in a
+compound command or inside the script — the first ten invocations work and the eleventh does
+not. Two habits remove it for good:
+
+- Pin the binary in a bash/zsh function that forwards `"$@"`, or `cd` to that checkout as the
+  first line of the script, instead of relying on ambient cwd:
+
+  ```bash
+  tap_cli () {
+    npx --prefix "/tap-capable/checkout" cypress tap -s 73952 "$@"
+  }
+  ```
+- When a dispatch fails, print stdout before deciding what went wrong. `Unknown command "tap"`
+  and a real dispatch failure are indistinguishable once stdout is gone.
+
+Confirm which binary is answering at any time with `npx cypress tap --help`: it needs no
+session, and it fails the same way when cwd is wrong.
+
+## Spec and run problems
+
+| Reported | Why | Do |
+| --- | --- | --- |
+| No spec has run yet. | Read a result before running anything | `tap run <spec>`, wait for a verdict |
+| The spec has not started yet. | Spec is still `loading`; Mocha has not started | Keep polling; the run-level loop owns the timeout |
+| The spec … is currently running. | App read attempted mid-run | Poll `status` until `passed`/`failed` |
+| The Cypress session has no spec matching that path. | Path is not in the specs list | `tap specs` for the exact path; if the file exists but is unlisted, widen `specPattern` |
+| The Cypress session could not start the spec. | The `runSpec` request failed | `tap status`, then retry |
+| That testing type is not configured for this project. | Spec belongs to a type the config does not define | Configure it, or open Cypress in a type the project supports. Note the session may never appear at all — see below |
+| The Cypress session has no project open. | Session sitting with no project | Open a project in Cypress |
+
+**A session for an unconfigured testing type never registers** — `cypress open --component`
+against a project with no `component` block leaves a live Cypress process that `tap sessions`
+does not list, so there is nothing to target and no "not configured" report to read. Worse, if
+an e2e session for that same project is running, auto-selection answers with *that* one, whose
+`passed` verdict reads like your component run succeeded. Check the `TYPE` column on `status`
+before believing a result, and configure the testing type before expecting to tap it.
+
+**`run` succeeds but nothing runs** — `status` stays at `spec not selected` while `run` keeps
+answering `▶ <spec>` with exit `0`. The session has stopped accepting run requests; seen once
+after two runs were put in flight at once. `sessions` still shows it healthy. Restart
+`cypress open`; the CLI cannot un-wedge it.
+
+This state is **rare and has not reproduced**: firing three runs into a spec mid-flight, and
+deleting the spec that was currently selected, were both re-tested deliberately and neither
+wedged the session — runs superseded cleanly and the next `run` worked. Keep one run in flight
+as discipline, but when a run seems lost, first rule out the two likelier explanations: a
+verdict that belongs to a *superseding* run (compare `spec`, not just `startedAt`), and a
+wedged or wrong session answering your calls (see above).
+
+A spec that **fails to build** is not an error — `status` reports `failed` with the reason in
+`error` and no test counts. Read `error`; it holds the bundler/compile failure. `reporter` is
+empty, and app reads may still succeed against an empty frame, so neither is the diagnostic.
+
+**A run you did not start** — `status` moves to `loading`/`running` on its own, or `startedAt`
+changes before your `run` lands. Open mode watches spec files and reruns the active spec when
+one is saved; measured here, `startedAt` moved within 3–6s of a write, sometimes with the
+rerun already finished. This is not a fault, but
+it breaks the verdict rule if the baseline `startedAt` was captured before the edit, and pairs
+with your own dispatch to put two runs in flight. After writing a spec, let the watcher's run
+reach a verdict, take the baseline from *there*, and only then dispatch — or let the watcher's
+run be the one you read.
+
+**Results disappear between commands** — `reporter` answers "No spec has run yet" and `status`
+drops to `spec not selected`, on a session that was fine a moment ago. Results live only in the
+app's memory, so an interrupted run, a restart, or deleting/renaming the spec that ran clears
+them. Nothing is broken: rerun the spec. The lesson is ordering — read everything you need out
+of a run *before* editing the spec, because the edit both drops the old results and starts a
+new run.
+
+## Ids that matched nothing
+
+| Reported | Do |
+| --- | --- |
+| No test in this spec matched that id. | `tap reporter` (no `--test-id`) lists the ids |
+| No attempt of this test matched that number. | `--attempt` is 1-based; the message names how many exist |
+| No command in this test matched that id. | `tap reporter --test-id <id>` lists the rows |
+| That command id matches more than one row of the test. | Qualify it as `<hookId>:<number>`, e.g. `h1:3` |
+| No snapshot of this command matched that name or index. | The message lists the available snapshots; `--at` takes a name or 1-based index |
+| That command has no DOM snapshot to pin. | Rerun the spec (snapshots are evicted per `numTestsKeptInMemory`), or pick a row whose `command` output lists snapshots |
+
+## App-under-test reads
+
+A selector matching nothing is not a CLI failure. `dom` and `inspect` report `found:false`
+with exit `0`; treat that as an absent element, not a broken session. `aria` returns an empty
+tree for either a miss or a matched element with no accessibility node, so confirm absence
+with `dom` or `inspect`.
+
+**Every expected element appears absent after a verdict** — first verify that the live frame is
+actually the app. A trailing pending/skipped test can leave the runner on a blank placeholder
+while `aria`, `dom`, and `inspect` continue to exit `0` with plausible empty/not-found results.
+Sanity-check a known app anchor. If the run ended on a pending test and the frame is blank, pin
+a snapshot from the last real command, inspect it, then `pin --clear`.
+
+| Reported | Why | Do |
+| --- | --- | --- |
+| Failed to determine the app under test in the Cypress session. | No app frame in the runner page | Rerun the spec; or `pin` a command to read an earlier snapshot |
+| ⚠ selector … matched N elements but must be unique | Ambiguous selector (exit `1`, matches listed on stdout) | Re-run with `--at <0-based index>` or a unique selector from the list |
+| Expected `--at` to be a whole number, 0 or greater. | Bad flag value | Fix the value; these are checked before a session is even resolved |
+
+## Invocation problems
+
+Unknown command, unknown flag, missing argument, missing required option — each prints what
+you gave, then the generated help for the command you called. `--help` works with no session
+running, so `npx cypress tap <command> --help` is always available as the source of truth.
+
+`MISSING_COMPANION_OPTION`-style failures name both flags: e.g. `--attempt` without
+`--test-id` (pass the test id, or drop `--attempt` for the spec-wide view).
+
+## When nothing above fits
+
+"An error occurred." / "The Cypress session failed while running the command." mean the
+failure carried no actionable condition. Get the diagnostic:
+
+```bash
+DEBUG=cypress:cli:tap,cypress:cli:cypress-sessions npx cypress tap <command> …
+```
+
+That prints the underlying stack, the resolved session, and the calls made — the detail to
+attach to a GitHub issue.


### PR DESCRIPTION
## Related issue

<!-- Link issue number if there is one, e.g. Closes #123 --> 
[AW-108](https://cypress-io.atlassian.net/browse/AW-108)

## Summary

<!-- What does this change and why? -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds documentation and agent instructions only; no runtime or security-sensitive application code changes.
> 
> **Overview**
> Introduces **`cypress-tap`**, a new agent skill that documents how to control an existing **`cypress open`** session via the **`cypress tap`** CLI—run specs, poll for fresh results, read reporter/command logs, and inspect or rewind the app with **`dom`**, **`aria`**, **`inspect`**, and **`pin`**.
> 
> The skill ships as **`skills/cypress-tap/SKILL.md`** plus reference guides (session lifecycle, results, app reads, recipes, troubleshooting), including strict workflows such as fresh-verdict polling after **`run`** and Cypress **15.21+** / Chromium-browser prerequisites.
> 
> **README** and **`skills/README.md`** now list four skills and add **`cypress-tap`** install examples for **`npx skills`** and **`gh skill`**. Claude and Cursor plugin metadata versions are bumped from **1.1.0** to **1.2.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e9b27011e775c60b70d38da7d388b4424b87097. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



[AW-108]: https://cypress-io.atlassian.net/browse/AW-108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ