### PR TITLE
feat: Add `cy-cloud` skill to README and update plugin versions to 1.3.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,7 @@
     {
       "name": "cypress",
       "description": "Create, update, and fix Cypress tests. Connect to Cypress Cloud to see test results and use data to manage your test suite.",
-      "version": "1.2.0",
+      "version": "1.3.0",
       "author": {
         "name": "Cypress.io",
         "email": "support@cypress.io",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cypress",
   "displayName": "Cypress",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Create, update, and fix Cypress tests. Connect to Cypress Cloud to see test results and use data to manage your test suite.",
   "author": {
     "name": "Cypress.io",

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "cypress",
   "displayName": "Cypress",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Create, update, and fix Cypress tests. Connect to Cypress Cloud to see test results and use data to manage your test suite.",
   "author": {
     "name": "Cypress.io",

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Five skills are available now:
 - **[`cypress-explain`](./skills/README.md#cypress-explain)** — Helps you understand, describe, and critique existing tests. Use it when auditing a suite, onboarding a new team member, or investigating a brittle test before rewriting it.
 - **[`cypress-docs`](./skills/README.md#cypress-docs)** - Helps your agent research and retrieve information about Cypress more efficiently and reliably.
 - **[`cypress-tap`](./skills/README.md#cypress-tap)** — Drives a running Cypress open-mode session to run specs, inspect results, diagnose failures, and query the app under test without GUI interaction.
-- **[`cy-cloud`](./skills/README.md#cy-cloud)** — Investigates Cypress Cloud runs, tests, failures, screenshots, and Test Replay data through the Cypress Cloud CLI.
+- **[`cypress-cloud-cli`](./skills/README.md#cypress-cloud-cli)** — Investigates Cypress Cloud runs, tests, failures, screenshots, and Test Replay data through the Cypress Cloud CLI.
 
 Skills work with any AI tool that accepts custom instructions, including Claude, Cursor, and GitHub Copilot.
 

--- a/README.md
+++ b/README.md
@@ -39,12 +39,13 @@ _Note:_ The MCP connection will utilize OAuth by default. If you would prefer to
 
 Skills are instruction sets your AI tool loads to apply Cypress-specific knowledge when generating or reviewing test code. They fill the gap between what an AI learned during training and what current, well-written Cypress tests actually look like.
 
-Four skills are available now:
+Five skills are available now:
 
 - **[`cypress-author`](./skills/README.md#cypress-author)** — Improves how AI tools create, update, and fix Cypress tests. Use it when you're writing new tests or fixing broken ones.
 - **[`cypress-explain`](./skills/README.md#cypress-explain)** — Helps you understand, describe, and critique existing tests. Use it when auditing a suite, onboarding a new team member, or investigating a brittle test before rewriting it.
 - **[`cypress-docs`](./skills/README.md#cypress-docs)** - Helps your agent research and retrieve information about Cypress more efficiently and reliably.
 - **[`cypress-tap`](./skills/README.md#cypress-tap)** — Drives a running Cypress open-mode session to run specs, inspect results, diagnose failures, and query the app under test without GUI interaction.
+- **[`cy-cloud`](./skills/README.md#cy-cloud)** — Investigates Cypress Cloud runs, tests, failures, screenshots, and Test Replay data through the Cypress Cloud CLI.
 
 Skills work with any AI tool that accepts custom instructions, including Claude, Cursor, and GitHub Copilot.
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -28,6 +28,7 @@ npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-author
 npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-explain
 npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-docs
 npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-tap
+npx skills add https://github.com/cypress-io/ai-toolkit --skill cy-cloud
 ```
 
 See [skills.sh](https://skills.sh/) for full documentation, including how to update and remove skills. Note that the update check in the `skills` package only tracks project-level installs, not global ones.
@@ -49,6 +50,7 @@ gh skill install cypress-io/ai-toolkit cypress-author
 gh skill install cypress-io/ai-toolkit cypress-explain
 gh skill install cypress-io/ai-toolkit cypress-docs
 gh skill install cypress-io/ai-toolkit cypress-tap
+gh skill install cypress-io/ai-toolkit cy-cloud
 ```
 
 See [GitHub](https://cli.github.com/manual/gh_skill) for full documentation, including how to keep skills up-to-date.
@@ -111,6 +113,17 @@ Use it when authoring or debugging Cypress tests against an existing `cypress op
 **Diagnose a failing spec:**
 
 > Run the checkout spec in my open Cypress session, diagnose the failure, and inspect the app at the failing command.
+
+### [`cy-cloud`](./cy-cloud)
+Investigates Cypress Cloud organizations, projects, runs, specs, tests, failure screenshots, and Test Replay data through the `cy-cloud` CLI.
+
+Use it to triage recorded failures and flakes from a Cypress Cloud URL or test ID. It requires Node.js 22.21.0 or later, the Cypress Cloud CLI, authentication, and an organization with the CLI integration enabled.
+
+#### Example
+
+**Investigate a recorded failure:**
+
+> Diagnose why this Cypress Cloud test failed, inspect its failed attempt and Test Replay data, and report the most likely root cause.
 
 ## Troubleshooting
 

--- a/skills/README.md
+++ b/skills/README.md
@@ -28,7 +28,7 @@ npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-author
 npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-explain
 npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-docs
 npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-tap
-npx skills add https://github.com/cypress-io/ai-toolkit --skill cy-cloud
+npx skills add https://github.com/cypress-io/ai-toolkit --skill cypress-cloud-cli
 ```
 
 See [skills.sh](https://skills.sh/) for full documentation, including how to update and remove skills. Note that the update check in the `skills` package only tracks project-level installs, not global ones.
@@ -50,7 +50,7 @@ gh skill install cypress-io/ai-toolkit cypress-author
 gh skill install cypress-io/ai-toolkit cypress-explain
 gh skill install cypress-io/ai-toolkit cypress-docs
 gh skill install cypress-io/ai-toolkit cypress-tap
-gh skill install cypress-io/ai-toolkit cy-cloud
+gh skill install cypress-io/ai-toolkit cypress-cloud-cli
 ```
 
 See [GitHub](https://cli.github.com/manual/gh_skill) for full documentation, including how to keep skills up-to-date.
@@ -114,7 +114,7 @@ Use it when authoring or debugging Cypress tests against an existing `cypress op
 
 > Run the checkout spec in my open Cypress session, diagnose the failure, and inspect the app at the failing command.
 
-### [`cy-cloud`](./cy-cloud)
+### [`cypress-cloud-cli`](./cypress-cloud-cli)
 Investigates Cypress Cloud organizations, projects, runs, specs, tests, failure screenshots, and Test Replay data through the `cy-cloud` CLI.
 
 Use it to triage recorded failures and flakes from a Cypress Cloud URL or test ID. It requires Node.js 22.21.0 or later, the Cypress Cloud CLI, authentication, and an organization with the CLI integration enabled.

--- a/skills/cy-cloud/SKILL.md
+++ b/skills/cy-cloud/SKILL.md
@@ -1,0 +1,340 @@
+---
+name: cy-cloud
+description: Runs the cy-cloud CLI to inspect Cypress Cloud organizations, projects, runs, specs, tests, failure screenshots, and Test Replay data. Use when the user mentions Cypress Cloud, cy-cloud, a Cloud run or test URL, failing or flaky Cypress tests, Test Replay, run triage, Cloud artifacts, or asks why a recorded test failed.
+metadata:
+  version: 1.0.0
+---
+
+# Cypress Cloud CLI
+
+Use `cy-cloud` directly to investigate Cypress Cloud. Execute the commands, inspect their JSON, and
+report conclusions supported by the returned data. Do not send the user to the Cloud UI when the CLI
+can answer the question.
+
+## Start safely
+
+The published binary requires Node.js 22.21.0 or newer.
+
+Run these checks only on first use, when the environment is unknown, or after an installation or
+authentication error. If `cy-cloud` already worked in this session, invoke the investigation command
+directly instead of spending another turn rechecking the setup.
+
+```bash
+node --version
+cy-cloud status
+cy-cloud --help
+```
+
+Assume `cy-cloud` is already installed and available on `PATH`. Run it from the user's current
+workspace; do not locate, clone, build, or depend on the cloud-cli source repository. If the command
+is unavailable, stop and report the missing prerequisite. The user can install it with:
+
+```bash
+npm install -g @cypress/cloud
+```
+
+If unauthenticated, ask the user to choose an authentication method:
+
+```bash
+cy-cloud login                 # interactive OAuth
+cy-cloud login --token "$PAT"  # persist a Personal Access Token
+```
+
+For CI or an existing environment, `CYPRESS_CLOUD_TOKEN` takes precedence over stored credentials
+and writes no credential file.
+
+Never print, echo, read back, or commit tokens. Never inspect
+`~/.config/cy-cloud/auth.json` or `cypress.env.json`; use `cy-cloud status`.
+
+The organization must have the Cypress Cloud CLI integration enabled. A response saying it is not
+enabled requires an organization administrator; it cannot be fixed with another CLI command.
+
+## Discover instead of guessing
+
+Every command supports:
+
+```bash
+cy-cloud <command> --help
+cy-cloud <command> --schema
+```
+
+Treat `--help` as authoritative for arguments and `--schema` as the intended response contract. Use
+them before constructing a query when a flag or field is uncertain. Validate the actual response
+too: `run get` can return a fractional `duration`, and `replay info.failedAt` can be a fractional
+epoch even when the schema declares an integer. Treat those values as numbers and report the schema
+mismatch if it matters; do not discard or round the data.
+
+Successful data commands write JSON to stdout. Pipe them to `jq`. Replay download progress is
+written to stderr, so never combine stderr with stdout before parsing JSON:
+
+```bash
+cy-cloud replay timeline --testId <uuid> --attempt <failedAttemptNumber> 2>/dev/null | jq
+```
+
+If a command fails, rerun without suppressing stderr. Argument-validation errors can appear on
+stdout; command execution errors appear on stderr. Both exit with status 1.
+
+When running from Cursor, Cloud-backed fetches may be blocked by the command sandbox even when local
+commands such as `status` succeed. Run Cloud data commands with unrestricted network permission. If
+a fetch fails with a sandbox or network denial, retry that same command with unrestricted network
+before diagnosing a CLI, authentication, or Cloud problem.
+
+## Command map
+
+```text
+version
+status
+login [--token PAT] [--timeout SECONDS]
+logout
+
+org list
+project list [--orgId UUID,...] [--page N] [--limit N]
+project get --projectId PROJECT_ID
+run list --projectId PROJECT_ID [--status STATUS,...] [--branch NAME,...] [--page N] [--limit N]
+run get --projectId PROJECT_ID --runNumber N
+spec list (--projectId PROJECT_ID --runNumber N | --specId UUID,...) [--status STATUS,...]
+spec get --specId UUID
+test list (--projectId PROJECT_ID --runNumber N | --specId UUID,... | --testId UUID,...)
+          [--status STATUS,...] [--page N] [--limit N]
+test get (--testId UUID | --testResultUrl URL) [--screenshot [DIRECTORY]]
+replay info (--testId UUID | --testResultUrl URL) [--attempt N]
+replay timeline (--testId UUID | --testResultUrl URL) [--attempt N] [filters]
+cache info
+cache cleanup
+cache clear
+```
+
+For `projectId`, use the project identifier already present in a Cloud URL; both the short slug and
+the project UUID are accepted by project/run lookups and run-scoped spec/test lists. Do not perform
+organization and project discovery merely to replace a UUID with a slug. `runNumber` is the
+per-project run number. `specId` and `testId` are UUIDs. Attempt numbers are 1-indexed, matching
+Cypress Cloud.
+
+Cloud list responses have `.pagination`; request more pages when the question is not limited to the
+first page. `replay timeline` is different: it accepts `--page` and `--limit` but returns only
+`.events`, with no pagination metadata. For an unfiltered `--all` query, compare returned event
+counts across pages with `replay info` totals (`commandEvents + networkEvents + logs`). Continue
+while a page returns the requested limit or the accumulated count is below that total.
+
+## Standard investigation
+
+Start broad only when the user did not provide a Cloud URL or test ID. A copied test overview URL
+can already contain the project identifier, run number, and test ID, including when it has a query
+string, so try it directly before discovery.
+
+```bash
+# Discover a project
+cy-cloud org list | jq '.organizations[] | {uuid, name}'
+cy-cloud project list --orgId <orgUuid> | jq '.projects[] | {projectId, name}'
+
+# Find recent failing runs
+cy-cloud run list --projectId <projectId> --status failed --limit 5 \
+  | jq '.runs[] | {runNumber, status, branch, createdAt}'
+
+# Find failed specs and tests
+cy-cloud spec list --projectId <projectId> --runNumber <runNumber> --status failed \
+  | jq '.specs[] | {id, path, status}'
+cy-cloud test list --projectId <projectId> --runNumber <runNumber> --status failed \
+  | jq '.tests[] | {projectId, testId, specFilepath, testName, status, attempts}'
+```
+
+When the user supplies a Cloud test overview or test-results URL, skip discovery:
+
+```bash
+cy-cloud test get --testResultUrl "<url>" \
+  | jq '{projectId, runNumber, specFilepath, testName, status, attempt, attempts,
+         failureScreenshotPath, failureScreenshotReason}'
+
+# Choose the failed attemptNumber from attempts[]; never rely on the final/default attempt for a flake.
+cy-cloud replay info --testResultUrl "<url>" --attempt <failedAttemptNumber> 2>/dev/null
+cy-cloud replay timeline --testResultUrl "<url>" --attempt <failedAttemptNumber> 2>/dev/null
+```
+
+Accepted paths include `/runs/<run>/overview/<testId>` and
+`/runs/<run>/test-results/<testId>`, with optional trailing paths and query strings. Pass
+`--testId` or `--testResultUrl`, never both.
+
+## Inspect the failure
+
+Get the test details first:
+
+```bash
+cy-cloud test get --testId <uuid> \
+  | jq '{projectId, runNumber, specFilepath, testName, status, attempt, attempts,
+         failureScreenshotPath, failureScreenshotReason}'
+```
+
+`attempts[]` provides `attemptNumber`, `errorName`, `errorMessage`, and `stackTrace`. Select the
+failed `attemptNumber` explicitly for every replay query. `test get` can report the final passing
+retry in `attempt`, so its default attempt is unsafe for flaky-test diagnosis.
+
+Only request a screenshot when `test get` identifies a failed selected result for which a failure
+screenshot can exist:
+
+```bash
+cy-cloud test get --testId <uuid> --screenshot ./artifacts \
+  | jq '{status, attempt, attempts, failureScreenshotPath, failureScreenshotReason}'
+```
+
+Read `failureScreenshotPath` only when the response actually returns a path. `test get` has no
+attempt selector, so a flaky test may select its final passing retry even though `attempts[]`
+contains an earlier failure. In that case, `--screenshot` returns
+`failureScreenshotReason: "test passed"` and cannot retrieve the failed-attempt screenshot; continue
+with the failed attempt's replay and source inspection instead of treating the absent file as
+missing evidence. Record this as an evidence gap in the conclusion: the CLI currently has no
+workaround for fetching that earlier attempt's screenshot, and its contents must not be inferred.
+
+There is no explicit flake status, `--status flaky` filter, or `flakyCount` field. Flake can only be
+inferred from `attempts[]`, so interpret retries carefully:
+
+- A final pass after an earlier failed attempt is evidence of flake.
+- Repeated failed attempts indicate a reproducible failure.
+- A single failed attempt does not prove the test is non-flaky; retries may be disabled.
+
+Cloud UI URLs can include filters such as `isFlaky=true`, but that query parameter is a UI filter,
+not a flake field exposed by the CLI. Reconstruct the UI's classification from `attempts[]`: find an
+earlier failed attempt followed by a passing retry.
+
+## Use Test Replay
+
+Check whether replay resolution succeeds and inspect the selected attempt:
+
+```bash
+cy-cloud replay info --testId <uuid> --attempt <failedAttemptNumber> 2>/dev/null
+```
+
+`replay info` has no availability boolean. A successful response means replay data resolved; an
+error means it is unavailable or inaccessible.
+
+With no filters, `replay timeline` returns the 25 commands leading to the failure, the failed
+command, and XHR/Fetch network events. Start with this default:
+
+```bash
+cy-cloud replay timeline --testId <uuid> --attempt <failedAttemptNumber> 2>/dev/null \
+  | jq '.events[] | {category, name, message, state, method, url, response}'
+```
+
+Then narrow or widen only as needed:
+
+```bash
+# Failed command
+cy-cloud replay timeline --testId <uuid> --attempt <failedAttemptNumber> --failedOnly 2>/dev/null
+
+# More commands around failure
+cy-cloud replay timeline --testId <uuid> --attempt <failedAttemptNumber> \
+  --aroundFailure 100 2>/dev/null
+
+# Network diagnosis
+cy-cloud replay timeline --testId <uuid> --attempt <failedAttemptNumber> --network All 2>/dev/null \
+  | jq '.events[] | select(.category == "network") | {method, url, status: .response.status}'
+
+# Application console output
+cy-cloud replay timeline --testId <uuid> --attempt <failedAttemptNumber> --logs 2>/dev/null \
+  | jq '.events[]
+        | select(.category == "log" and .payload)
+        | (.payload | fromjson?)
+        | select(.)
+        | {type, msg: [.args[]? | .value // .description]}'
+
+# Full timeline; page because this can be large
+cy-cloud replay timeline --testId <uuid> --attempt <failedAttemptNumber> \
+  --all --limit 200 --page 1 2>/dev/null
+
+# Compare a passing retry without pulling task and code-coverage payloads
+cy-cloud replay timeline --testId <uuid> --attempt <passingAttemptNumber> \
+  --commands --limit 100 --page 1 2>/dev/null \
+  | jq '.events[] | {name, message, state}'
+```
+
+Any explicit filter disables the default failure context. For example, `--logs` returns only logs.
+To add logs while retaining useful failure context, specify every desired category:
+
+```bash
+cy-cloud replay timeline --testId <uuid> --attempt <failedAttemptNumber> \
+  --commands --aroundFailure 25 --network XHR,Fetch --logs 2>/dev/null
+```
+
+Timeline events share an ordered `.events[]` array and use `category` values `command`, `network`,
+and `log`. Preserve array order when correlating events: command events may not expose a usable
+timestamp field. Use timestamps when an event provides one and compare timestamp-bearing logs and
+network events with `replay info.failedAt`; otherwise use array position relative to the failed
+command. Ignore events after the failure unless the question specifically concerns teardown or
+post-failure behavior. Dev-server messages emitted after `failedAt`, such as
+`Invalid Host/Origin header`, are not evidence for the assertion failure.
+
+The default network filter can silently return zero events for applications whose traffic is
+recorded under resource types other than XHR or Fetch. If the default timeline has no network
+events, rerun with `--network All` before concluding there was no network activity for an end-to-end
+spec. For a unit or component-testing spec, first inspect `replay info.networkEvents` and the test
+setup. If `networkEvents` is `0` and dependencies are mocked or the component is not exercising an
+application backend, skip `--network All`; it adds noise without new evidence.
+
+Network events do not include a `resourceType` field in their output. `--network` can filter by
+resource type, but the returned events cannot identify that type. If the type distribution matters,
+query the relevant types separately and compare each result's `.events | length`.
+
+The first replay request downloads and caches a SQLite database, often for an entire spec. Later
+queries for that spec are local and faster.
+
+## Diagnose, do not merely restate
+
+Use this evidence order:
+
+1. Test details and all attempts.
+2. Select the failed attempt and pass its `attemptNumber` via `--attempt` to every replay query.
+3. Failure screenshot, only when a path exists for a failed selected result.
+4. Default replay failure context for that failed attempt.
+5. For end-to-end specs, if the default has no network events, rerun with `--network All`; skip this
+   for mocked unit/component specs whose `replay info.networkEvents` is `0`.
+6. Network failures, missing requests, or incomplete responses before the failed command.
+7. Application console errors at or before `failedAt`, parsing the JSON string in `payload`.
+8. A passing attempt or passing run for comparison when the cause remains ambiguous. Start with
+   `--commands`; do not use `--all` for the initial comparison because task events can contain very
+   large code-coverage payloads.
+9. If replay establishes only the assertion symptom, use the stack trace to read the spec and
+   relevant source. Inspect the immediately preceding and following tests plus their hooks,
+   especially when tests pass alone but fail in sequence. Check module-level state, globals,
+   aliases, mocks, and fixtures that an adjacent test mutates and `beforeEach` does not reset. Cloud
+   artifacts can reveal the symptom without revealing why the state already had that value.
+
+For "element never appeared" failures, check in order:
+
+1. A preceding 4xx or 5xx response.
+2. A request that never completed.
+3. An expected request that never started.
+4. A console exception.
+5. Selector, timing, or rendering behavior visible in the screenshot and command timeline.
+
+Report:
+
+- the project/run/spec/test that was inspected;
+- the failing attempt and Cypress command;
+- the visible symptom and assertion;
+- the most likely root cause, with timeline/network/log evidence;
+- whether retry history suggests flake, or `unknown` when attempts are insufficient;
+- uncertainty and the next discriminating check when evidence is incomplete.
+
+## Cache and common recovery
+
+```bash
+cy-cloud cache info
+cy-cloud cache cleanup
+cy-cloud cache clear
+```
+
+Use `cache cleanup` for normal maintenance. Use `cache clear` only when replay resolution appears
+stale or corrupted because it forces future replay downloads.
+
+Common outcomes:
+
+- `Replay not available`: use test details and the screenshot when one exists; no replay can be
+  fetched.
+- `No matching records found for testId and attempt`: verify the 1-indexed attempt with
+  `replay info`.
+- Empty replay events: rerun with no filters, then `--commands`; use paged `--all` only when the
+  investigation needs every category because task events can contain large payloads.
+- Missing expected fields: inspect that command's `--schema`.
+- `jq` parse failure: ensure stderr was not merged into stdout.
+- `cy-cloud version` reporting `"status": "Unknown"` does not by itself mean the installation is
+  broken or outdated. Compare `version` and `latestVersion`; upgrade only when those values or an
+  explicit compatibility error indicate it.

--- a/skills/cypress-cloud-cli/SKILL.md
+++ b/skills/cypress-cloud-cli/SKILL.md
@@ -204,7 +204,7 @@ cy-cloud replay info --testId <uuid> --attempt <failedAttemptNumber> 2>/dev/null
 ```
 
 `replay info` has no availability boolean. A successful response means replay data resolved; an
-error means it is unavailable or inaccessible.
+error means it is not yet available or inaccessible.
 
 With no filters, `replay timeline` returns the 25 commands leading to the failure, the failed
 command, and XHR/Fetch network events. Start with this default:

--- a/skills/cypress-cloud-cli/SKILL.md
+++ b/skills/cypress-cloud-cli/SKILL.md
@@ -54,55 +54,49 @@ enabled requires an organization administrator; it cannot be fixed with another 
 Every command supports:
 
 ```bash
+cy-cloud --help
 cy-cloud <command> --help
 cy-cloud <command> --schema
 ```
 
-Treat `--help` as authoritative for arguments and `--schema` as the intended response contract. Use
-them before constructing a query when a flag or field is uncertain. Validate the actual response
-too: `run get` can return a fractional `duration`, and `replay info.failedAt` can be a fractional
-epoch even when the schema declares an integer. Treat those values as numbers and report the schema
-mismatch if it matters; do not discard or round the data.
+Treat `cy-cloud --help` as authoritative for available commands, per-command `--help` as
+authoritative for arguments, and `--schema` as the intended response contract. Use them before
+constructing a query when a command, flag, or field is uncertain. Do not memorize a command
+inventory from this skill; the installed CLI may be newer or older than these instructions.
+Validate the actual response too: `run get` can return a fractional `duration`, and
+`replay info.failedAt` can be a fractional epoch even when the schema declares an integer. Treat
+those values as numbers and report the schema mismatch if it matters; do not discard or round the
+data.
 
-Successful data commands write JSON to stdout. Pipe them to `jq`. Replay download progress is
-written to stderr, so never combine stderr with stdout before parsing JSON:
+Successful data commands write JSON to stdout. Parse that JSON directly; do not install a JSON
+tool to run this skill. Replay download progress is written to stderr, so never combine stderr with
+stdout before parsing JSON:
 
 ```bash
-cy-cloud replay timeline --testId <uuid> --attempt <failedAttemptNumber> 2>/dev/null | jq
+cy-cloud replay timeline --testId <uuid> --attempt <failedAttemptNumber> 2>/dev/null
 ```
 
 If a command fails, rerun without suppressing stderr. Argument-validation errors can appear on
 stdout; command execution errors appear on stderr. Both exit with status 1.
 
-When running from Cursor, Cloud-backed fetches may be blocked by the command sandbox even when local
-commands such as `status` succeed. Run Cloud data commands with unrestricted network permission. If
-a fetch fails with a sandbox or network denial, retry that same command with unrestricted network
-before diagnosing a CLI, authentication, or Cloud problem.
+Cloud-backed fetches may be blocked by security sandboxes even when local commands such as `status`
+succeed. Run Cloud data commands with network access allowed. If a fetch fails with a sandbox or
+network denial, retry that same command with broader network permission before diagnosing a CLI,
+authentication, or Cloud problem.
 
-## Command map
+Replay downloads are cached on disk. Confirm the location with `cy-cloud cache info` (`.location`)
+and run Cloud commands so that directory can be written and still exists later in this session. An
+ephemeral sandbox that cannot persist it will re-download replay data or fail cache validation,
+including on otherwise local commands. Do not relocate the cache into the user's project.
 
-```text
-version
-status
-login [--token PAT] [--timeout SECONDS]
-logout
+Cloud API calls are rate limited per user. Prefer considered, methodical requests: reuse
+identifiers already in a URL or prior response, skip org and project discovery when an ID is
+known, and do not page further than the question requires. After the first replay download for a
+test, `replay info` and `replay timeline` run against the local cache and do not count against
+that limit, so those follow-up queries can be chatty. If a command reports an exceeded rate
+limit, stop issuing Cloud-backed requests and report the limit; do not retry in a tight loop.
 
-org list
-project list [--orgId UUID,...] [--page N] [--limit N]
-project get --projectId PROJECT_ID
-run list --projectId PROJECT_ID [--status STATUS,...] [--branch NAME,...] [--page N] [--limit N]
-run get --projectId PROJECT_ID --runNumber N
-spec list (--projectId PROJECT_ID --runNumber N | --specId UUID,...) [--status STATUS,...]
-spec get --specId UUID
-test list (--projectId PROJECT_ID --runNumber N | --specId UUID,... | --testId UUID,...)
-          [--status STATUS,...] [--page N] [--limit N]
-test get (--testId UUID | --testResultUrl URL) [--screenshot [DIRECTORY]]
-replay info (--testId UUID | --testResultUrl URL) [--attempt N]
-replay timeline (--testId UUID | --testResultUrl URL) [--attempt N] [filters]
-cache info
-cache cleanup
-cache clear
-```
+## Identifiers and pagination
 
 For `projectId`, use the project identifier already present in a Cloud URL; both the short slug and
 the project UUID are accepted by project/run lookups and run-scoped spec/test lists. Do not perform
@@ -111,208 +105,20 @@ per-project run number. `specId` and `testId` are UUIDs. Attempt numbers are 1-i
 Cypress Cloud.
 
 Cloud list responses have `.pagination`; request more pages when the question is not limited to the
-first page. `replay timeline` is different: it accepts `--page` and `--limit` but returns only
-`.events`, with no pagination metadata. For an unfiltered `--all` query, compare returned event
-counts across pages with `replay info` totals (`commandEvents + networkEvents + logs`). Continue
-while a page returns the requested limit or the accumulated count is below that total.
+first page.
 
-## Standard investigation
+## Route by task
 
-Start broad only when the user did not provide a Cloud URL or test ID. A copied test overview URL
-can already contain the project identifier, run number, and test ID, including when it has a query
-string, so try it directly before discovery.
+Read only the references required for the current task:
 
-```bash
-# Discover a project
-cy-cloud org list | jq '.organizations[] | {uuid, name}'
-cy-cloud project list --orgId <orgUuid> | jq '.projects[] | {projectId, name}'
-
-# Find recent failing runs
-cy-cloud run list --projectId <projectId> --status failed --limit 5 \
-  | jq '.runs[] | {runNumber, status, branch, createdAt}'
-
-# Find failed specs and tests
-cy-cloud spec list --projectId <projectId> --runNumber <runNumber> --status failed \
-  | jq '.specs[] | {id, path, status}'
-cy-cloud test list --projectId <projectId> --runNumber <runNumber> --status failed \
-  | jq '.tests[] | {projectId, testId, specFilepath, testName, status, attempts}'
-```
-
-When the user supplies a Cloud test overview or test-results URL, skip discovery:
-
-```bash
-cy-cloud test get --testResultUrl "<url>" \
-  | jq '{projectId, runNumber, specFilepath, testName, status, attempt, attempts,
-         failureScreenshotPath, failureScreenshotReason}'
-
-# Choose the failed attemptNumber from attempts[]; never rely on the final/default attempt for a flake.
-cy-cloud replay info --testResultUrl "<url>" --attempt <failedAttemptNumber> 2>/dev/null
-cy-cloud replay timeline --testResultUrl "<url>" --attempt <failedAttemptNumber> 2>/dev/null
-```
-
-Accepted paths include `/runs/<run>/overview/<testId>` and
-`/runs/<run>/test-results/<testId>`, with optional trailing paths and query strings. Pass
-`--testId` or `--testResultUrl`, never both.
-
-## Inspect the failure
-
-Get the test details first:
-
-```bash
-cy-cloud test get --testId <uuid> \
-  | jq '{projectId, runNumber, specFilepath, testName, status, attempt, attempts,
-         failureScreenshotPath, failureScreenshotReason}'
-```
-
-`attempts[]` provides `attemptNumber`, `errorName`, `errorMessage`, and `stackTrace`. Select the
-failed `attemptNumber` explicitly for every replay query. `test get` can report the final passing
-retry in `attempt`, so its default attempt is unsafe for flaky-test diagnosis.
-
-Only request a screenshot when `test get` identifies a failed selected result for which a failure
-screenshot can exist:
-
-```bash
-cy-cloud test get --testId <uuid> --screenshot ./artifacts \
-  | jq '{status, attempt, attempts, failureScreenshotPath, failureScreenshotReason}'
-```
-
-Read `failureScreenshotPath` only when the response actually returns a path. `test get` has no
-attempt selector, so a flaky test may select its final passing retry even though `attempts[]`
-contains an earlier failure. In that case, `--screenshot` returns
-`failureScreenshotReason: "test passed"` and cannot retrieve the failed-attempt screenshot; continue
-with the failed attempt's replay and source inspection instead of treating the absent file as
-missing evidence. Record this as an evidence gap in the conclusion: the CLI currently has no
-workaround for fetching that earlier attempt's screenshot, and its contents must not be inferred.
-
-There is no explicit flake status, `--status flaky` filter, or `flakyCount` field. Flake can only be
-inferred from `attempts[]`, so interpret retries carefully:
-
-- A final pass after an earlier failed attempt is evidence of flake.
-- Repeated failed attempts indicate a reproducible failure.
-- A single failed attempt does not prove the test is non-flaky; retries may be disabled.
-
-Cloud UI URLs can include filters such as `isFlaky=true`, but that query parameter is a UI filter,
-not a flake field exposed by the CLI. Reconstruct the UI's classification from `attempts[]`: find an
-earlier failed attempt followed by a passing retry.
-
-## Use Test Replay
-
-Check whether replay resolution succeeds and inspect the selected attempt:
-
-```bash
-cy-cloud replay info --testId <uuid> --attempt <failedAttemptNumber> 2>/dev/null
-```
-
-`replay info` has no availability boolean. A successful response means replay data resolved; an
-error means it is unavailable or inaccessible.
-
-With no filters, `replay timeline` returns the 25 commands leading to the failure, the failed
-command, and XHR/Fetch network events. Start with this default:
-
-```bash
-cy-cloud replay timeline --testId <uuid> --attempt <failedAttemptNumber> 2>/dev/null \
-  | jq '.events[] | {category, name, message, state, method, url, response}'
-```
-
-Then narrow or widen only as needed:
-
-```bash
-# Failed command
-cy-cloud replay timeline --testId <uuid> --attempt <failedAttemptNumber> --failedOnly 2>/dev/null
-
-# More commands around failure
-cy-cloud replay timeline --testId <uuid> --attempt <failedAttemptNumber> \
-  --aroundFailure 100 2>/dev/null
-
-# Network diagnosis
-cy-cloud replay timeline --testId <uuid> --attempt <failedAttemptNumber> --network All 2>/dev/null \
-  | jq '.events[] | select(.category == "network") | {method, url, status: .response.status}'
-
-# Application console output
-cy-cloud replay timeline --testId <uuid> --attempt <failedAttemptNumber> --logs 2>/dev/null \
-  | jq '.events[]
-        | select(.category == "log" and .payload)
-        | (.payload | fromjson?)
-        | select(.)
-        | {type, msg: [.args[]? | .value // .description]}'
-
-# Full timeline; page because this can be large
-cy-cloud replay timeline --testId <uuid> --attempt <failedAttemptNumber> \
-  --all --limit 200 --page 1 2>/dev/null
-
-# Compare a passing retry without pulling task and code-coverage payloads
-cy-cloud replay timeline --testId <uuid> --attempt <passingAttemptNumber> \
-  --commands --limit 100 --page 1 2>/dev/null \
-  | jq '.events[] | {name, message, state}'
-```
-
-Any explicit filter disables the default failure context. For example, `--logs` returns only logs.
-To add logs while retaining useful failure context, specify every desired category:
-
-```bash
-cy-cloud replay timeline --testId <uuid> --attempt <failedAttemptNumber> \
-  --commands --aroundFailure 25 --network XHR,Fetch --logs 2>/dev/null
-```
-
-Timeline events share an ordered `.events[]` array and use `category` values `command`, `network`,
-and `log`. Preserve array order when correlating events: command events may not expose a usable
-timestamp field. Use timestamps when an event provides one and compare timestamp-bearing logs and
-network events with `replay info.failedAt`; otherwise use array position relative to the failed
-command. Ignore events after the failure unless the question specifically concerns teardown or
-post-failure behavior. Dev-server messages emitted after `failedAt`, such as
-`Invalid Host/Origin header`, are not evidence for the assertion failure.
-
-The default network filter can silently return zero events for applications whose traffic is
-recorded under resource types other than XHR or Fetch. If the default timeline has no network
-events, rerun with `--network All` before concluding there was no network activity for an end-to-end
-spec. For a unit or component-testing spec, first inspect `replay info.networkEvents` and the test
-setup. If `networkEvents` is `0` and dependencies are mocked or the component is not exercising an
-application backend, skip `--network All`; it adds noise without new evidence.
-
-Network events do not include a `resourceType` field in their output. `--network` can filter by
-resource type, but the returned events cannot identify that type. If the type distribution matters,
-query the relevant types separately and compare each result's `.events | length`.
-
-The first replay request downloads and caches a SQLite database, often for an entire spec. Later
-queries for that spec are local and faster.
-
-## Diagnose, do not merely restate
-
-Use this evidence order:
-
-1. Test details and all attempts.
-2. Select the failed attempt and pass its `attemptNumber` via `--attempt` to every replay query.
-3. Failure screenshot, only when a path exists for a failed selected result.
-4. Default replay failure context for that failed attempt.
-5. For end-to-end specs, if the default has no network events, rerun with `--network All`; skip this
-   for mocked unit/component specs whose `replay info.networkEvents` is `0`.
-6. Network failures, missing requests, or incomplete responses before the failed command.
-7. Application console errors at or before `failedAt`, parsing the JSON string in `payload`.
-8. A passing attempt or passing run for comparison when the cause remains ambiguous. Start with
-   `--commands`; do not use `--all` for the initial comparison because task events can contain very
-   large code-coverage payloads.
-9. If replay establishes only the assertion symptom, use the stack trace to read the spec and
-   relevant source. Inspect the immediately preceding and following tests plus their hooks,
-   especially when tests pass alone but fail in sequence. Check module-level state, globals,
-   aliases, mocks, and fixtures that an adjacent test mutates and `beforeEach` does not reset. Cloud
-   artifacts can reveal the symptom without revealing why the state already had that value.
-
-For "element never appeared" failures, check in order:
-
-1. A preceding 4xx or 5xx response.
-2. A request that never completed.
-3. An expected request that never started.
-4. A console exception.
-5. Selector, timing, or rendering behavior visible in the screenshot and command timeline.
-
-Report:
-
-- the project/run/spec/test that was inspected;
-- the failing attempt and Cypress command;
-- the visible symptom and assertion;
-- the most likely root cause, with timeline/network/log evidence;
-- whether retry history suggests flake, or `unknown` when attempts are insufficient;
-- uncertainty and the next discriminating check when evidence is incomplete.
+- **Find orgs, projects, runs, specs, or tests, or open a Cloud URL:** read
+  [investigation.md](references/investigation.md).
+- **Inspect attempts, flakes, or failure screenshots:** read
+  [investigation.md](references/investigation.md).
+- **Query Test Replay:** read [investigation.md](references/investigation.md) and
+  [test-replay.md](references/test-replay.md).
+- **Diagnose why a recorded test failed:** read [investigation.md](references/investigation.md),
+  [test-replay.md](references/test-replay.md), and [diagnosis.md](references/diagnosis.md).
 
 ## Cache and common recovery
 
@@ -323,18 +129,19 @@ cy-cloud cache clear
 ```
 
 Use `cache cleanup` for normal maintenance. Use `cache clear` only when replay resolution appears
-stale or corrupted because it forces future replay downloads.
+stale or corrupted because it forces future replay downloads. If replay re-downloads every
+command, the cache directory is not persisting; retry with a sandbox that can write to the
+location reported by `cache info`.
 
 Common outcomes:
 
-- `Replay not available`: use test details and the screenshot when one exists; no replay can be
-  fetched.
-- `No matching records found for testId and attempt`: verify the 1-indexed attempt with
-  `replay info`.
-- Empty replay events: rerun with no filters, then `--commands`; use paged `--all` only when the
-  investigation needs every category because task events can contain large payloads.
 - Missing expected fields: inspect that command's `--schema`.
-- `jq` parse failure: ensure stderr was not merged into stdout.
+- JSON parse failure: ensure stderr was not merged into stdout.
+- Cache validation or write errors from the sandbox: retry so the cache directory is writable
+  and persistent; do not copy the cache into the project.
 - `cy-cloud version` reporting `"status": "Unknown"` does not by itself mean the installation is
   broken or outdated. Compare `version` and `latestVersion`; upgrade only when those values or an
   explicit compatibility error indicate it.
+- Exceeded rate limit: stop Cloud-backed requests and report the limit; do not retry in a loop.
+  Cached replay queries are exempt once the download has succeeded.
+- Replay-specific errors: read [test-replay.md](references/test-replay.md).

--- a/skills/cypress-cloud-cli/SKILL.md
+++ b/skills/cypress-cloud-cli/SKILL.md
@@ -1,6 +1,6 @@
 ---
-name: cy-cloud
-description: Runs the cy-cloud CLI to inspect Cypress Cloud organizations, projects, runs, specs, tests, failure screenshots, and Test Replay data. Use when the user mentions Cypress Cloud, cy-cloud, a Cloud run or test URL, failing or flaky Cypress tests, Test Replay, run triage, Cloud artifacts, or asks why a recorded test failed.
+name: cypress-cloud-cli
+description: Runs the cy-cloud CLI to inspect Cypress Cloud organizations, projects, runs, specs, tests, failure screenshots, and Test Replay data. Use when the user mentions Cypress Cloud, cy-cloud, cypress-cloud-cli, a Cloud run or test URL, failing or flaky Cypress tests, Test Replay, run triage, Cloud artifacts, or asks why a recorded test failed.
 metadata:
   version: 1.0.0
 ---

--- a/skills/cypress-cloud-cli/SKILL.md
+++ b/skills/cypress-cloud-cli/SKILL.md
@@ -47,7 +47,7 @@ Never print, echo, read back, or commit tokens. Never inspect
 `~/.config/cy-cloud/auth.json` or `cypress.env.json`; use `cy-cloud status`.
 
 The organization must have the Cypress Cloud CLI integration enabled. A response saying it is not
-enabled requires an organization administrator; it cannot be fixed with another CLI command.
+enabled requires action from an organization administrator; it cannot be fixed with another CLI command.
 
 ## Discover instead of guessing
 

--- a/skills/cypress-cloud-cli/references/diagnosis.md
+++ b/skills/cypress-cloud-cli/references/diagnosis.md
@@ -1,0 +1,38 @@
+# Diagnosis
+
+Do not merely restate Cloud fields. Use this evidence order after reading
+[investigation.md](investigation.md) and, when replay is available, [test-replay.md](test-replay.md):
+
+1. Test details and all attempts.
+2. Select the failed attempt and pass its `attemptNumber` via `--attempt` to every replay query.
+3. Failure screenshot, only when a path exists for a failed selected result.
+4. Default replay failure context for that failed attempt.
+5. For end-to-end specs, if the default has no network events, rerun with `--network All`; skip this
+   for mocked unit/component specs whose `replay info.networkEvents` is `0`.
+6. Network failures, missing requests, or incomplete responses before the failed command.
+7. Application console errors at or before `failedAt`, parsing the JSON string in `payload`.
+8. A passing attempt or passing run for comparison when the cause remains ambiguous. Start with
+   `--commands`; do not use `--all` for the initial comparison because task events can contain very
+   large code-coverage payloads.
+9. If replay establishes only the assertion symptom, use the stack trace to read the spec and
+   relevant source. Inspect the immediately preceding and following tests plus their hooks,
+   especially when tests pass alone but fail in sequence. Check module-level state, globals,
+   aliases, mocks, and fixtures that an adjacent test mutates and `beforeEach` does not reset. Cloud
+   artifacts can reveal the symptom without revealing why the state already had that value.
+
+For "element never appeared" failures, check in order:
+
+1. A preceding 4xx or 5xx response.
+2. A request that never completed.
+3. An expected request that never started.
+4. A console exception.
+5. Selector, timing, or rendering behavior visible in the screenshot and command timeline.
+
+Report:
+
+- the project/run/spec/test that was inspected;
+- the failing attempt and Cypress command;
+- the visible symptom and assertion;
+- the most likely root cause, with timeline/network/log evidence;
+- whether retry history suggests flake, or `unknown` when attempts are insufficient;
+- uncertainty and the next discriminating check when evidence is incomplete.

--- a/skills/cypress-cloud-cli/references/investigation.md
+++ b/skills/cypress-cloud-cli/references/investigation.md
@@ -1,0 +1,81 @@
+# Investigation
+
+Start broad only when the user did not provide a Cloud URL or test ID. A copied test overview URL
+can already contain the project identifier, run number, and test ID, including when it has a query
+string, so try it directly before discovery.
+
+```bash
+# Discover a project
+cy-cloud org list
+cy-cloud project list --orgId <orgUuid>
+
+# Find recent failing runs
+cy-cloud run list --projectId <projectId> --status failed --limit 5
+
+# Find failed specs and tests
+cy-cloud spec list --projectId <projectId> --runNumber <runNumber> --status failed
+cy-cloud test list --projectId <projectId> --runNumber <runNumber> --status failed
+```
+
+From those responses, inspect organization `uuid` and `name`; project `projectId` and `name`; run
+`runNumber`, `status`, `branch`, and `createdAt`; spec `id`, `path`, and `status`; and test
+`projectId`, `testId`, `specFilepath`, `testName`, `status`, and `attempts`.
+
+When the user supplies a Cloud test overview or test-results URL, skip discovery:
+
+```bash
+cy-cloud test get --testResultUrl "<url>"
+```
+
+Inspect `projectId`, `runNumber`, `specFilepath`, `testName`, `status`, `attempt`, `attempts`,
+`failureScreenshotPath`, and `failureScreenshotReason`.
+
+Choose the failed `attemptNumber` from `attempts[]` before any replay query; never rely on the
+final/default attempt for a flake. Then read [test-replay.md](test-replay.md).
+
+Accepted paths include `/runs/<run>/overview/<testId>` and
+`/runs/<run>/test-results/<testId>`, with optional trailing paths and query strings. Pass
+`--testId` or `--testResultUrl`, never both.
+
+## Inspect the failure
+
+Get the test details first:
+
+```bash
+cy-cloud test get --testId <uuid>
+```
+
+Inspect `projectId`, `runNumber`, `specFilepath`, `testName`, `status`, `attempt`, `attempts`,
+`failureScreenshotPath`, and `failureScreenshotReason`.
+
+`attempts[]` provides `attemptNumber`, `errorName`, `errorMessage`, and `stackTrace`. Select the
+failed `attemptNumber` explicitly for every replay query. `test get` can report the final passing
+retry in `attempt`, so its default attempt is unsafe for flaky-test diagnosis.
+
+Only request a screenshot when `test get` identifies a failed selected result for which a failure
+screenshot can exist:
+
+```bash
+cy-cloud test get --testId <uuid> --screenshot ./artifacts
+```
+
+Inspect `status`, `attempt`, `attempts`, `failureScreenshotPath`, and `failureScreenshotReason`.
+
+Read `failureScreenshotPath` only when the response actually returns a path. `test get` has no
+attempt selector, so a flaky test may select its final passing retry even though `attempts[]`
+contains an earlier failure. In that case, `--screenshot` returns
+`failureScreenshotReason: "test passed"` and cannot retrieve the failed-attempt screenshot; continue
+with the failed attempt's replay and source inspection instead of treating the absent file as
+missing evidence. Record this as an evidence gap in the conclusion: the CLI currently has no
+workaround for fetching that earlier attempt's screenshot, and its contents must not be inferred.
+
+There is no explicit flake status, `--status flaky` filter, or `flakyCount` field. Flake can only be
+inferred from `attempts[]`, so interpret retries carefully:
+
+- A final pass after an earlier failed attempt is evidence of flake.
+- Repeated failed attempts indicate a reproducible failure.
+- A single failed attempt does not prove the test is non-flaky; retries may be disabled.
+
+Cloud UI URLs can include filters such as `isFlaky=true`, but that query parameter is a UI filter,
+not a flake field exposed by the CLI. Reconstruct the UI's classification from `attempts[]`: find an
+earlier failed attempt followed by a passing retry.

--- a/skills/cypress-cloud-cli/references/test-replay.md
+++ b/skills/cypress-cloud-cli/references/test-replay.md
@@ -1,0 +1,99 @@
+# Test Replay
+
+Select the failed `attemptNumber` from `attempts[]` before every replay query. See
+[investigation.md](investigation.md) if that attempt is not yet known.
+
+Check whether replay resolution succeeds and inspect the selected attempt:
+
+```bash
+cy-cloud replay info --testId <uuid> --attempt <failedAttemptNumber> 2>/dev/null
+```
+
+`replay info` has no availability boolean. A successful response means replay data resolved; an
+error means it is unavailable or inaccessible.
+
+With no filters, `replay timeline` returns the 25 commands leading to the failure, the failed
+command, and XHR/Fetch network events. Start with this default:
+
+```bash
+cy-cloud replay timeline --testId <uuid> --attempt <failedAttemptNumber> 2>/dev/null
+```
+
+Inspect each event's `category`, `name`, `message`, `state`, `method`, `url`, and `response`.
+
+Then narrow or widen only as needed:
+
+```bash
+# Failed command
+cy-cloud replay timeline --testId <uuid> --attempt <failedAttemptNumber> --failedOnly 2>/dev/null
+
+# More commands around failure
+cy-cloud replay timeline --testId <uuid> --attempt <failedAttemptNumber> \
+  --aroundFailure 100 2>/dev/null
+
+# Network diagnosis
+cy-cloud replay timeline --testId <uuid> --attempt <failedAttemptNumber> --network All 2>/dev/null
+
+# Application console output
+cy-cloud replay timeline --testId <uuid> --attempt <failedAttemptNumber> --logs 2>/dev/null
+
+# Full timeline; page because this can be large
+cy-cloud replay timeline --testId <uuid> --attempt <failedAttemptNumber> \
+  --all --limit 200 --page 1 2>/dev/null
+
+# Compare a passing retry without pulling task and code-coverage payloads
+cy-cloud replay timeline --testId <uuid> --attempt <passingAttemptNumber> \
+  --commands --limit 100 --page 1 2>/dev/null
+```
+
+For network events, inspect `method`, `url`, and `response.status`. Log events store console output
+as a JSON string in `payload`; parse that string and read `type` plus each argument's `value` or
+`description`. For command comparisons, inspect `name`, `message`, and `state`.
+
+Any explicit filter disables the default failure context. For example, `--logs` returns only logs.
+To add logs while retaining useful failure context, specify every desired category:
+
+```bash
+cy-cloud replay timeline --testId <uuid> --attempt <failedAttemptNumber> \
+  --commands --aroundFailure 25 --network XHR,Fetch --logs 2>/dev/null
+```
+
+`replay timeline` accepts `--page` and `--limit` but returns only `.events`, with no pagination
+metadata. For an unfiltered `--all` query, compare returned event counts across pages with
+`replay info` totals (`commandEvents + networkEvents + logs`). Continue while a page returns the
+requested limit or the accumulated count is below that total.
+
+Timeline events share an ordered `.events[]` array and use `category` values `command`, `network`,
+and `log`. Preserve array order when correlating events: command events may not expose a usable
+timestamp field. Use timestamps when an event provides one and compare timestamp-bearing logs and
+network events with `replay info.failedAt`; otherwise use array position relative to the failed
+command. Ignore events after the failure unless the question specifically concerns teardown or
+post-failure behavior. Dev-server messages emitted after `failedAt`, such as
+`Invalid Host/Origin header`, are not evidence for the assertion failure.
+
+The default network filter can silently return zero events for applications whose traffic is
+recorded under resource types other than XHR or Fetch. If the default timeline has no network
+events, rerun with `--network All` before concluding there was no network activity for an end-to-end
+spec. For a unit or component-testing spec, first inspect `replay info.networkEvents` and the test
+setup. If `networkEvents` is `0` and dependencies are mocked or the component is not exercising an
+application backend, skip `--network All`; it adds noise without new evidence.
+
+Network events do not include a `resourceType` field in their output. `--network` can filter by
+resource type, but the returned events cannot identify that type. If the type distribution matters,
+query the relevant types separately and compare each result's `.events | length`.
+
+The first replay request downloads and caches a SQLite database, often for an entire spec, and
+that download counts as a Cloud API request. Later `replay info` and `replay timeline` queries
+for that spec are local, do not count against the rate limit, and can be chatty — but only when
+that cache directory still exists.
+
+## Replay recovery
+
+- `Replay not available`: use test details and the screenshot when one exists; no replay can be
+  fetched.
+- `No matching records found for testId and attempt`: verify the 1-indexed attempt with
+  `replay info`.
+- Empty replay events: rerun with no filters, then `--commands`; use paged `--all` only when the
+  investigation needs every category because task events can contain large payloads.
+
+To turn replay evidence into a root-cause conclusion, read [diagnosis.md](diagnosis.md).


### PR DESCRIPTION
## Related issue

<!-- Link issue number if there is one, e.g. Closes #123 -->
close: [AW-107](https://cypress-io.atlassian.net/browse/AW-107)

## Summary

<!-- What does this change and why? -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and agent skill content only; no application runtime or auth implementation changes in this repo.
> 
> **Overview**
> Ships a new **`cypress-cloud-cli`** agent skill so assistants can triage Cypress Cloud via **`cy-cloud`** (runs, tests, screenshots, Test Replay) instead of sending users to the UI. The skill includes **`SKILL.md`** plus reference guides for investigation, replay queries, and root-cause diagnosis (auth, rate limits, cache, flaky attempts, stderr/JSON parsing).
> 
> **README** and **`skills/README.md`** now list five skills and document install via `npx skills` / `gh skill install`. Claude and Cursor plugin manifests are bumped from **1.2.0** to **1.3.0**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8f6261f5ee071442ef04715349f3ae36b6c2965. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

[AW-107]: https://cypress-io.atlassian.net/browse/AW-107?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ